### PR TITLE
Improved memory performance by avoiding array copy

### DIFF
--- a/src/console/pulseq_interpreter/sequence_provider.py
+++ b/src/console/pulseq_interpreter/sequence_provider.py
@@ -84,6 +84,8 @@ class SequenceProvider(Sequence):
         self.spcm_freq = 1 / spcm_dwell_time
         self.spcm_dwell_time = spcm_dwell_time
 
+        self.ring_buffer_size: int | None = None
+
         try:
             if len(gradient_efficiency) != 3:
                 raise ValueError("Invalid number of gradient efficiency values, 3 values must be provided")
@@ -493,8 +495,20 @@ class SequenceProvider(Sequence):
                 "Number of sequence samples does not match total number of block samples"
             )
 
+        if self.ring_buffer_size is not None:
+            # Ensure the size of the sequence array is an integer multiple of ring buffer size
+            seq_mem_size = 4 * seq_samples * 2  # Calulate the size in memory of the sequence array
+            mem_mismatch = seq_mem_size % self.ring_buffer_size.value
+            if mem_mismatch > 0:
+                self.log.debug("Sequence array size is not an integer multiple of ring buffer size")
+                append_bytes = self.ring_buffer_size.value - mem_mismatch
+                append_samples = int(append_bytes/2)  # Each sample is 2 bytes
+                self.log.debug(f"Appending {append_samples} samples to the sequence array")
+        else:
+            append_samples = 0
+
         # Setup output arrays
-        _seq = np.zeros(4 * seq_samples, dtype=np.int16)
+        _seq = np.zeros(4 * seq_samples + append_samples, dtype=np.int16)
         _adc = np.zeros(seq_samples, dtype=np.uint16)
         _unblanking = np.zeros(seq_samples, dtype=np.uint16)
 

--- a/src/console/spcm_control/acquisition_control.py
+++ b/src/console/spcm_control/acquisition_control.py
@@ -101,6 +101,8 @@ class AcquisitionControl:
         self.f_spcm = self.rx_card.sample_rate * 1e6
         # Set sequence provider max. amplitude per channel according to values from tx_card
         self.seq_provider.max_amp_per_channel = self.tx_card.max_amplitude
+        # Pass the ring buffer size to sequence provider
+        self.seq_provider.ring_buffer_size = self.tx_card.ring_buffer_size
 
         self.unrolled_seq: UnrolledSequence | None = None
 


### PR DESCRIPTION
Substantially improved memory performance (up to 50% reduction, sequence dependent) by avoiding an array copy that took place if the sequence array memory footprint was not an integer multiple of ring buffer size. Previous implementation appended zeros to the sequence array, here the sequence array is initialised in the 'correct' size, avoiding the array copy that takes place in the append function. 

The original code for appending the array is still in place in case the sequence array is still not the correct size.