### PR TITLE
Prevent sequence extension before execution

### DIFF
--- a/src/console/spcm_control/abstract_device.py
+++ b/src/console/spcm_control/abstract_device.py
@@ -5,7 +5,7 @@ from ctypes import _SimpleCData, byref, c_char_p, create_string_buffer
 from logging import Logger
 
 import console.spcm_control.spcm.pyspcm as sp
-from console.spcm_control.spcm.tools import translate_error, type_to_name, translate_status
+from console.spcm_control.spcm.tools import translate_error, translate_status, type_to_name
 
 
 class SpectrumDevice(ABC):
@@ -109,7 +109,6 @@ class SpectrumDevice(ABC):
                 )
                 sp.spcm_dwSetParam_i32(self.card, sp.SPC_M2CMD, sp.M2CMD_CARD_STOP)
                 raise RuntimeError
-
 
     def get_status(self) -> int:
         """Get and log current card status.

--- a/src/console/spcm_control/abstract_device.py
+++ b/src/console/spcm_control/abstract_device.py
@@ -5,13 +5,19 @@ from ctypes import _SimpleCData, byref, c_char_p, create_string_buffer
 from logging import Logger
 
 import console.spcm_control.spcm.pyspcm as sp
-from console.spcm_control.spcm.tools import translate_error, type_to_name
+from console.spcm_control.spcm.tools import translate_error, type_to_name, translate_status
 
 
 class SpectrumDevice(ABC):
     """Spectrum device abstract base class."""
 
-    def __init__(self, path: str, log: Logger):
+    card: c_char_p | None
+    card_type: sp.int32
+    name: str | None
+    path: str
+    log: Logger
+
+    def __init__(self, path: str, log: Logger) -> None:
         """Init function of spectrum device.
 
         Parameters
@@ -20,12 +26,12 @@ class SpectrumDevice(ABC):
             Path of the spectrum card device, e.g. /dev/spcm1
         """
         super().__init__()
-        self.card: c_char_p | None = None
-        self.name: str | None = None
+        self.card = None
+        self.card_type = sp.int32(0)
+        self.name = None
         self.path = path
         self.log = log
 
-    @abstractmethod
     def dict(self) -> dict:
         """Abstract method which returns variables for logging in dictionary."""
         attributes = {}
@@ -46,12 +52,13 @@ class SpectrumDevice(ABC):
                 attributes[key] = var
         return attributes
 
-    def disconnect(self):
+    def disconnect(self) -> None:
         """Disconnect card."""
         # Closing the card
         if self.card:
             self.log.info(f"Stopping and closing card {self.name}...")
             sp.spcm_dwSetParam_i32(self.card, sp.SPC_M2CMD, sp.M2CMD_CARD_STOP)
+            sp.spcm_dwSetParam_i32(self.card, sp.SPC_M2CMD, sp.M2CMD_CARD_RESET)
             sp.spcm_vClose(self.card)
             # Reset card information
             self.card = None
@@ -76,9 +83,8 @@ class SpectrumDevice(ABC):
         self.card = sp.spcm_hOpen(create_string_buffer(str.encode(self.path)))
         if self.card:
             # Read card information
-            card_type = sp.int32(0)
-            sp.spcm_dwGetParam_i32(self.card, sp.SPC_PCITYP, byref(card_type))
-            self.name = type_to_name(card_type.value)
+            sp.spcm_dwGetParam_i32(self.card, sp.SPC_PCITYP, byref(self.card_type))
+            self.name = type_to_name(self.card_type.value)
             self.log.debug(f"Connection to card {self.name} established!")
             self.setup_card()
         else:
@@ -86,7 +92,7 @@ class SpectrumDevice(ABC):
             raise ConnectionError("Could not connect to card")
         return True
 
-    def handle_error(self, error: int):
+    def handle_error(self, error: int) -> None:
         """General error handling function."""
         if error != sp.ERR_OK:
             # sp.ERR_OK = 0, this corresponds to "if error:"
@@ -104,16 +110,34 @@ class SpectrumDevice(ABC):
                     sp.spcm_dwSetParam_i32(self.card, sp.SPC_M2CMD, sp.M2CMD_CARD_STOP)
                     raise RuntimeError
 
-    @abstractmethod
+
     def get_status(self) -> int:
-        """Abstract method to obtain card status."""
+        """Get and log current card status.
+
+        The status is represented by a list. Each entry represents a possible card status in form
+        of a (sub-)list. It contains the status code, name and (optional) description of the spectrum
+        instrumentation manual.
+
+        Returns
+        -------
+            String with status description.
+        """
+        try:
+            status = sp.int32(0)
+            sp.spcm_dwGetParam_i32(self.card, sp.SPC_M2STATUS, byref(status))
+            if self.log:
+                msg, _ = translate_status(status.value, include_desc=False)
+                self.log.debug("Card status:\n%s", {key: val for val, key in msg.values()})
+        except Exception:
+            self.log.exception("Error getting card status.")
+        return status.value
 
     @abstractmethod
-    def setup_card(self):
+    def setup_card(self) -> None:
         """Abstract method to setup the card."""
 
     @abstractmethod
-    def start_operation(self):
+    def start_operation(self) -> None:
         """Abstract method to start card operation.
 
         Parameters
@@ -123,5 +147,5 @@ class SpectrumDevice(ABC):
         """
 
     @abstractmethod
-    def stop_operation(self):
+    def stop_operation(self) -> None:
         """Abstract method to stop card operation."""

--- a/src/console/spcm_control/abstract_device.py
+++ b/src/console/spcm_control/abstract_device.py
@@ -97,18 +97,18 @@ class SpectrumDevice(ABC):
         if error != sp.ERR_OK:
             # sp.ERR_OK = 0, this corresponds to "if error:"
             if error == sp.ERR_TIMEOUT:
-                # Check for timeout
-                self.log.debug("Timeout")
-            else:
-                # Read error message from card
-                err_msg = create_string_buffer(sp.ERRORTEXTLEN)
-                if (sp.spcm_dwGetErrorInfo_i32(self.card, None, None, err_msg) != sp.ERR_OK):
-                    # double check if error is not ERR_OK, disconnect and raise error
-                    self.log.critical(
-                        f"Catched error ( {error} ): {err_msg}, {translate_error(error)}; Stopping card {self.name}"
-                    )
-                    sp.spcm_dwSetParam_i32(self.card, sp.SPC_M2CMD, sp.M2CMD_CARD_STOP)
-                    raise RuntimeError
+                # Check for timeout, could be logged but occurs in normal operation
+                # self.log.debug("Received timeout")
+                return
+            # Read error message from card
+            err_msg = create_string_buffer(sp.ERRORTEXTLEN)
+            if (sp.spcm_dwGetErrorInfo_i32(self.card, None, None, err_msg) != sp.ERR_OK):
+                # double check if error is not ERR_OK, disconnect and raise error
+                self.log.critical(
+                    f"Catched error ( {error} ): {err_msg}, {translate_error(error)}; Stopping card {self.name}"
+                )
+                sp.spcm_dwSetParam_i32(self.card, sp.SPC_M2CMD, sp.M2CMD_CARD_STOP)
+                raise RuntimeError
 
 
     def get_status(self) -> int:

--- a/src/console/spcm_control/acquisition_control.py
+++ b/src/console/spcm_control/acquisition_control.py
@@ -80,9 +80,16 @@ class AcquisitionControl:
 
         # Setup the cards
         self.is_setup: bool = False
-        if self.tx_card.connect() and self.rx_card.connect():
-            self.log.info("Setup of measurement cards successful.")
-            self.is_setup = True
+        try:
+            if self.tx_card.connect() and self.rx_card.connect():
+                self.log.info("Setup of measurement cards successful.")
+                self.is_setup = True
+        except Exception:
+            self.log.exception("Error during card connection.")
+            if self.tx_card:
+                self.tx_card.disconnect()
+            if self.rx_card:
+                self.rx_card.disconnect()
 
         # Get the rx sampling rate for DDC
         self.f_spcm = self.rx_card.sample_rate * 1e6

--- a/src/console/spcm_control/acquisition_control.py
+++ b/src/console/spcm_control/acquisition_control.py
@@ -213,7 +213,9 @@ class AcquisitionControl:
 
             # Start masurement card operations
             self.rx_card.start_operation()
-            time.sleep(0.01)
+            while not self.rx_card.is_receiving.is_set():
+                time.sleep(0.01)
+                # self.log.debug("Waiting for RX card to start receiving...")
             self.tx_card.start_operation(self.sequence)
 
             # Get start time of acquisition

--- a/src/console/spcm_control/rx_device.py
+++ b/src/console/spcm_control/rx_device.py
@@ -10,7 +10,7 @@ import numpy as np
 
 import console.spcm_control.spcm.pyspcm as sp
 from console.spcm_control.abstract_device import SpectrumDevice
-from console.spcm_control.spcm.tools import create_dma_buffer, translate_status, type_to_name
+from console.spcm_control.spcm.tools import create_dma_buffer, type_to_name
 
 # Define registers lists
 CH_SELECT = [
@@ -53,18 +53,25 @@ getcontext().prec = 28
 class RxCard(SpectrumDevice):
     """Implementation of RX device."""
 
-    path: str
-    sample_rate: int
-    channel_enable: list[int]
-    max_amplitude: list[int]
-    impedance_50_ohms: list[int]
-
     __name__: str = "RxCard"
 
-    def __post_init__(self):
+    def __init__(
+        self,
+        path: str,
+        sample_rate: int,
+        channel_enable: list[int],
+        max_amplitude: list[int],
+        impedance_50_ohms: list[int],
+    ) -> None:
         """Execute after init function to do further class setup."""
         self.log = logging.getLogger(self.__name__)
-        super().__init__(self.path, log=self.log)
+        super().__init__(path, log=self.log)
+
+        self.sample_rate = sample_rate
+        self.channel_enable = channel_enable
+        self.max_amplitude = max_amplitude
+        self.impedance_50_ohms = impedance_50_ohms
+
         self.num_channels = sp.int32(0)
         self.card_type = sp.int32(0)
 
@@ -75,17 +82,8 @@ class RxCard(SpectrumDevice):
         self.pre_trigger = 8
         self.post_trigger = 4096
 
-        self.rx_data = []
+        self.rx_data: list = []
         self.rx_scaling = [amp / (2**15) for amp in self.max_amplitude]
-
-    def dict(self) -> dict:
-        """Returnt class variables which are json serializable as dictionary.
-
-        Returns
-        -------
-            Dictionary containing class variables.
-        """
-        return super().dict()
 
     def setup_card(self):
         """Set up spectrum card in transmit (TX) mode.
@@ -212,7 +210,7 @@ class RxCard(SpectrumDevice):
         sp.spcm_dwSetParam_i32(self.card, sp.SPC_TIMEOUT, 10)
 
         self.log.debug("Device setup completed")
-        self.log_card_status()
+        _ = self.get_status()
 
     def start_operation(self):
         """Start card operation."""
@@ -438,36 +436,3 @@ class RxCard(SpectrumDevice):
                         break
 
         self.log.debug("Card operation stopped")
-
-    def get_status(self) -> int:
-        """Get the current card status.
-
-        Returns
-        -------
-            String with status description.
-        """
-        try:
-            if not self.card:
-                raise ConnectionError("No device found")
-        except ConnectionError as err:
-            self.log.exception(err, exc_info=True)
-            raise err
-        status = sp.int32(0)
-        sp.spcm_dwGetParam_i32(self.card, sp.SPC_M2STATUS, byref(status))
-        return status.value
-
-    def log_card_status(self, include_desc: bool = False) -> None:
-        """Log current card status.
-
-        The status is represented by a list. Each entry represents a possible card status in form
-        of a (sub-)list. It contains the status code, name and (optional) description of the spectrum
-        instrumentation manual.
-
-        Parameters
-        ----------
-        include_desc, optional
-            Flag which indicates if description string should be contained in status entry, by default False
-        """
-        msg, _ = translate_status(self.get_status(), include_desc=include_desc)
-        status = {key: val for val, key in msg.values()}
-        self.log.debug("Card status:\n%s", status)

--- a/src/console/spcm_control/rx_device.py
+++ b/src/console/spcm_control/rx_device.py
@@ -77,6 +77,7 @@ class RxCard(SpectrumDevice):
 
         self.worker: threading.Thread | None = None
         self.is_running = threading.Event()
+        self.is_receiving = threading.Event()
 
         # Pre trigger is set to minimum and post trigger size is at least one notify size to avoid data loss.
         self.pre_trigger = 8
@@ -216,6 +217,7 @@ class RxCard(SpectrumDevice):
         """Start card operation."""
         # Clear the emergency stop flag
         self.is_running.clear()
+        self.is_receiving.clear()
         self.rx_data = []
         # Start card thread. if time stamp mode is not available use the example function.
         self.worker = threading.Thread(target=self._gated_timestamps_stream)
@@ -231,13 +233,11 @@ class RxCard(SpectrumDevice):
             # Stop the card. We will stop the card in two steps.
             # First we will stop the data transfer and then we will stop the card.
             # If time stamp mode is enabled, we need to stop the extra data transfer as well.
-            error = sp.spcm_dwSetParam_i32(
+            self.handle_error(sp.spcm_dwSetParam_i32(
                 self.card,
                 sp.SPC_M2CMD,
                 sp.M2CMD_CARD_STOP | sp.M2CMD_DATA_STOPDMA | sp.M2CMD_EXTRA_STOPDMA,
-            )
-            self.handle_error(error)
-            self.worker = None
+            ))
         else:
             # No thread is running
             self.log.error("No active process found")
@@ -302,6 +302,7 @@ class RxCard(SpectrumDevice):
 
         # Start receiver
         self.log.debug("Starting receive")
+        self.is_receiving.set()
 
         while not self.is_running.is_set():
 

--- a/src/console/spcm_control/rx_device.py
+++ b/src/console/spcm_control/rx_device.py
@@ -210,7 +210,7 @@ class RxCard(SpectrumDevice):
         sp.spcm_dwSetParam_i32(self.card, sp.SPC_TIMEOUT, 10)
 
         self.log.debug("Device setup completed")
-        _ = self.get_status()
+        # _ = self.get_status()
 
     def start_operation(self):
         """Start card operation."""

--- a/src/console/spcm_control/spcm/tools.py
+++ b/src/console/spcm_control/spcm/tools.py
@@ -119,4 +119,10 @@ def create_dma_buffer(buffer_size: int):
         dwOffset = dwAlignment - misalignment
     else:
         dwOffset = 0
-    return (c_char * buffer_size).from_buffer(pvNonAlignedBuf, dwOffset)
+
+    aligned_buffer = (c_char * buffer_size).from_buffer(pvNonAlignedBuf, dwOffset)
+
+    # zero the aligned buffer explicitly
+    memset(addressof(aligned_buffer), 0, buffer_size)
+
+    return aligned_buffer

--- a/src/console/spcm_control/tx_device.py
+++ b/src/console/spcm_control/tx_device.py
@@ -2,7 +2,6 @@
 import ctypes
 import logging
 import threading
-from dataclasses import dataclass
 
 import numpy as np
 
@@ -10,10 +9,9 @@ import console.spcm_control.spcm.pyspcm as spcm
 from console.interfaces.acquisition_parameter import Dimensions
 from console.interfaces.unrolled_sequence import UnrolledSequence
 from console.spcm_control.abstract_device import SpectrumDevice
-from console.spcm_control.spcm.tools import create_dma_buffer, translate_status, type_to_name
+from console.spcm_control.spcm.tools import create_dma_buffer, type_to_name
 
 
-@dataclass
 class TxCard(SpectrumDevice):
     """
     Implementation of TX device.
@@ -31,62 +29,34 @@ class TxCard(SpectrumDevice):
     The ring buffer is filled in fractions of notify_size.
     """
 
-    path: str
-    max_amplitude: list[int]
-    filter_type: list[int]
-    sample_rate: int
-    notify_rate: int = 16
-
     __name__: str = "TxCard"
 
-    def __post_init__(self):
-        """Post init function which is required to use dataclass arguments."""
+    def __init__(
+        self,
+        path: str,
+        max_amplitude: list[int],
+        filter_type: list[int],
+        sample_rate: int,
+        notify_rate: int = 16,
+    ) -> None:
         self.log = logging.getLogger(self.__name__)
-        super().__init__(self.path, log=self.log)
+        super().__init__(path=path, log=self.log)
+        self.max_amplitude = max_amplitude
+        self.filter_type = filter_type
+        self.sample_rate = sample_rate
+        self.notify_rate = notify_rate
 
         # Number of output channels is fixed
         self.num_ch = 4
         # Size of the current sequence
-        self.data_buffer_size = int(0)
-        # Define ring buffer and notify size, 512 MSamples * 2 Bytes = 1024 MB
-        self.ring_buffer_size: spcm.uint64 = spcm.uint64(1024**3)
-        self.card_type = spcm.int32(0)
+        self.data_buffer_size: int = 0
 
-        try:
-            # Check if ring buffer size is multiple of 2*num_ch (2 bytes per sample per channel)
-            if self.ring_buffer_size.value % (self.num_ch * 2) != 0:
-                raise MemoryError(
-                    "Ring buffer size is not a multiple of channel sample product \
-                    (number of enables channels times 2 byte per sample)"
-                )
-        except MemoryError as err:
-            self.log.exception(err, exc_info=True)
-            raise err
-
-        if self.ring_buffer_size.value % self.notify_rate == 0:
-            self.notify_size = spcm.int32(int(self.ring_buffer_size.value / self.notify_rate))
-        else:
-            # Set default fraktion to 16, notify size equals 1/16 of ring buffer size
-            self.notify_size = spcm.int32(int(self.ring_buffer_size.value / 16))
-
-        self.log.debug(
-            "Ring buffer size: %s; Notify size: %s",
-            self.ring_buffer_size.value,
-            self.notify_size.value,
-        )
+        # Define maximum ring buffer size, 512 MSamples * 2 Bytes = 1024 MB
+        self.max_ring_buffer_size: spcm.uint64 = spcm.uint64(1024**3)
 
         # Threading class attributes
         self.worker: threading.Thread | None = None
         self.is_running = threading.Event()
-
-    def dict(self) -> dict:
-        """Returnt class variables which are json serializable as dictionary.
-
-        Returns
-        -------
-            Dictionary containing class variables.
-        """
-        return super().dict()
 
     def setup_card(self) -> None:
         """Set up spectrum card in transmit (TX) mode.
@@ -103,7 +73,7 @@ class TxCard(SpectrumDevice):
             class attribute is overwritten.
         """
         # Reset card
-        spcm.spcm_dwSetParam_i64(self.card, spcm.SPC_M2CMD, spcm.M2CMD_CARD_RESET)
+        self.handle_error(spcm.spcm_dwSetParam_i64(self.card, spcm.SPC_M2CMD, spcm.M2CMD_CARD_RESET))
         spcm.spcm_dwGetParam_i32(self.card, spcm.SPC_PCITYP, ctypes.byref(self.card_type))
 
         try:
@@ -119,27 +89,16 @@ class TxCard(SpectrumDevice):
         card_features = spcm.int32(0)
         spcm.spcm_dwGetParam_i32(self.card, spcm.SPC_PCIFEATURES, ctypes.byref(card_features))
 
-        if card_features.value & (spcm.SPCM_FEAT_DIG16_FX2 | spcm.SPCM_FEAT_DIG16_SMB):
-            self.log.info("IO expansion card with FX2 connector detected")
-            self.has_IO_expansion = True
-        else:
-            self.has_IO_expansion = False
-
-        # >> TODO: At this point, card alread has M2STAT_CARD_PRETRIGGER and M2STAT_CARD_TRIGGER set, correct?
-
         # Set trigger
         spcm.spcm_dwSetParam_i32(self.card, spcm.SPC_TRIG_ORMASK, spcm.SPC_TMASK_SOFTWARE)
 
-        # Set clock mode, internal PLL and clock output enable
-        # spcm.spcm_dwSetParam_i32(self.card, spcm.SPC_CLOCKMODE, spcm.SPC_CM_INTPLL)
-        # spcm.spcm_dwSetParam_i32(self.card, spcm.SPC_CLOCKOUT, 1)
         # Configure external clock, TX master clock
-        spcm.spcm_dwSetParam_i32(self.card, spcm.SPC_CLOCKMODE, spcm.SPC_CM_EXTERNAL)
-        spcm.spcm_dwSetParam_i32(self.card, spcm.SPC_CLOCK50OHM, 1)
-        spcm.spcm_dwSetParam_i32(self.card, spcm.SPC_CLOCK_THRESHOLD, 1500)
+        self.handle_error(spcm.spcm_dwSetParam_i32(self.card, spcm.SPC_CLOCKMODE, spcm.SPC_CM_EXTERNAL))
+        self.handle_error(spcm.spcm_dwSetParam_i32(self.card, spcm.SPC_CLOCK50OHM, 1))
+        self.handle_error(spcm.spcm_dwSetParam_i32(self.card, spcm.SPC_CLOCK_THRESHOLD, 1500))
 
         # set card sampling rate in MHz
-        spcm.spcm_dwSetParam_i64(self.card, spcm.SPC_SAMPLERATE, spcm.MEGA(self.sample_rate))
+        self.handle_error(spcm.spcm_dwSetParam_i64(self.card, spcm.SPC_SAMPLERATE, spcm.MEGA(self.sample_rate)))
 
         # Check actual sampling rate
         sample_rate = spcm.int64(0)
@@ -154,74 +113,78 @@ class TxCard(SpectrumDevice):
             self.sample_rate = int(sample_rate.value * 1e-6)
 
         # Enable and setup channels
-        spcm.spcm_dwSetParam_i32(
+        self.handle_error(spcm.spcm_dwSetParam_i32(
             self.card,
             spcm.SPC_CHENABLE,
             spcm.CHANNEL0 | spcm.CHANNEL1 | spcm.CHANNEL2 | spcm.CHANNEL3,
-        )
+        ))
 
         self.log.info("Setup max. output amplitude: %s.", self.max_amplitude)
 
         # Use loop to enable and setup active channels
         # Channel 0: RF
-        spcm.spcm_dwSetParam_i32(self.card, spcm.SPC_ENABLEOUT0, 1)
-        spcm.spcm_dwSetParam_i32(self.card, spcm.SPC_AMP0, self.max_amplitude[0])
-        spcm.spcm_dwSetParam_i32(self.card, spcm.SPC_FILTER0, self.filter_type[0])
+        self.handle_error(spcm.spcm_dwSetParam_i32(self.card, spcm.SPC_ENABLEOUT0, 1))
+        self.handle_error(spcm.spcm_dwSetParam_i32(self.card, spcm.SPC_AMP0, self.max_amplitude[0]))
+        self.handle_error(spcm.spcm_dwSetParam_i32(self.card, spcm.SPC_FILTER0, self.filter_type[0]))
 
         # Channel 1: Gradient x, synchronus digital output: gate trigger
-        spcm.spcm_dwSetParam_i32(self.card, spcm.SPC_ENABLEOUT1, 1)
-        spcm.spcm_dwSetParam_i32(self.card, spcm.SPC_AMP1, self.max_amplitude[1])
-        spcm.spcm_dwSetParam_i32(self.card, spcm.SPC_FILTER1, self.filter_type[1])
+        self.handle_error(spcm.spcm_dwSetParam_i32(self.card, spcm.SPC_ENABLEOUT1, 1))
+        self.handle_error(spcm.spcm_dwSetParam_i32(self.card, spcm.SPC_AMP1, self.max_amplitude[1]))
+        self.handle_error(spcm.spcm_dwSetParam_i32(self.card, spcm.SPC_FILTER1, self.filter_type[1]))
 
         # Channel 2: Gradient y, synchronus digital output: un-blanking
-        spcm.spcm_dwSetParam_i32(self.card, spcm.SPC_ENABLEOUT2, 1)
-        spcm.spcm_dwSetParam_i32(self.card, spcm.SPC_AMP2, self.max_amplitude[2])
-        spcm.spcm_dwSetParam_i32(self.card, spcm.SPC_FILTER2, self.filter_type[2])
+        self.handle_error(spcm.spcm_dwSetParam_i32(self.card, spcm.SPC_ENABLEOUT2, 1))
+        self.handle_error(spcm.spcm_dwSetParam_i32(self.card, spcm.SPC_AMP2, self.max_amplitude[2]))
+        self.handle_error(spcm.spcm_dwSetParam_i32(self.card, spcm.SPC_FILTER2, self.filter_type[2]))
 
         # Channel 3: Gradient z
-        spcm.spcm_dwSetParam_i32(self.card, spcm.SPC_ENABLEOUT3, 1)
-        spcm.spcm_dwSetParam_i32(self.card, spcm.SPC_AMP3, self.max_amplitude[3])
-        spcm.spcm_dwSetParam_i32(self.card, spcm.SPC_FILTER3, self.filter_type[3])
+        self.handle_error(spcm.spcm_dwSetParam_i32(self.card, spcm.SPC_ENABLEOUT3, 1))
+        self.handle_error(spcm.spcm_dwSetParam_i32(self.card, spcm.SPC_AMP3, self.max_amplitude[3]))
+        self.handle_error(spcm.spcm_dwSetParam_i32(self.card, spcm.SPC_FILTER3, self.filter_type[3]))
 
         # Setup the card in FIFO mode
-        spcm.spcm_dwSetParam_i32(self.card, spcm.SPC_CARDMODE, spcm.SPC_REP_FIFO_SINGLE)
+        self.handle_error(spcm.spcm_dwSetParam_i32(self.card, spcm.SPC_CARDMODE, spcm.SPC_REP_FIFO_SINGLE))
 
         # >> Setup digital output channels
         # Channel X1: dig. ADC gate (15th bit from analog channel 1)
-        spcm.spcm_dwSetParam_i32(
+        self.handle_error(spcm.spcm_dwSetParam_i32(
             self.card,
             spcm.SPCM_X1_MODE,
             (spcm.SPCM_XMODE_DIGOUT | spcm.SPCM_XMODE_DIGOUTSRC_CH1 | spcm.SPCM_XMODE_DIGOUTSRC_BIT15),
-        )
-        if self.has_IO_expansion:
-            # Replicate ADC gate on extension port X12
-            spcm.spcm_dwSetParam_i32(
-                self.card,
-                spcm.SPCM_X12_MODE,
-                (spcm.SPCM_XMODE_DIGOUT | spcm.SPCM_XMODE_DIGOUTSRC_CH1 | spcm.SPCM_XMODE_DIGOUTSRC_BIT15),
-            )
+        ))
         # Channel X2: dig. reference signal (15th bit from analog channel 2)
-        spcm.spcm_dwSetParam_i32(
+        self.handle_error(spcm.spcm_dwSetParam_i32(
             self.card,
             spcm.SPCM_X2_MODE,
             (spcm.SPCM_XMODE_DIGOUT | spcm.SPCM_XMODE_DIGOUTSRC_CH2 | spcm.SPCM_XMODE_DIGOUTSRC_BIT15),
-        )
-        # Channel X3, X12: dig. unblanking signal (15th bit of analog channel 3)
-        spcm.spcm_dwSetParam_i32(
+        ))
+        # Channel X3: dig. unblanking signal (15th bit of analog channel 3)
+        self.handle_error(spcm.spcm_dwSetParam_i32(
             self.card,
             spcm.SPCM_X3_MODE,
             (spcm.SPCM_XMODE_DIGOUT | spcm.SPCM_XMODE_DIGOUTSRC_CH3 | spcm.SPCM_XMODE_DIGOUTSRC_BIT15),
-        )
-        if self.has_IO_expansion:
+        ))
+
+        # >> Setup additional GPIO ports, if extender is available
+        if card_features.value & (spcm.SPCM_FEAT_DIG16_FX2 | spcm.SPCM_FEAT_DIG16_SMB):
+            self.log.info("IO expansion card with FX2 connector detected, performing additional setup...")
+
+            # Replicate ADC gate on extension port X12
+            self.handle_error(spcm.spcm_dwSetParam_i32(
+                self.card,
+                spcm.SPCM_X12_MODE,
+                (spcm.SPCM_XMODE_DIGOUT | spcm.SPCM_XMODE_DIGOUTSRC_CH1 | spcm.SPCM_XMODE_DIGOUTSRC_BIT15),
+            ))
+
             # Replicate unblanking signal at extension port X13
-            spcm.spcm_dwSetParam_i32(
+            self.handle_error(spcm.spcm_dwSetParam_i32(
                 self.card,
                 spcm.SPCM_X13_MODE,
                 (spcm.SPCM_XMODE_DIGOUT | spcm.SPCM_XMODE_DIGOUTSRC_CH3 | spcm.SPCM_XMODE_DIGOUTSRC_BIT15),
-            )
+            ))
 
         self.log.debug("Device setup completed")
-        self.log_card_status()
+        _ = self.get_status()
 
     def set_gradient_offsets(self, offsets: Dimensions, high_impedance: list[bool] = [True, True, True]) -> None:
         """Set offset values of the gradient output channels.
@@ -321,22 +284,6 @@ class TxCard(SpectrumDevice):
             if not self.card:
                 raise ConnectionError("No connection to card established...")
 
-
-            # TODO: Get rid of the sequence extension here...
-            # TODO: Instead implement a function which transfers a notify size of data from the sequence, 
-            # and only fills the last tiny bit in the end if necessary
-
-            # Extend the provided data array with zeros to obtain a multiple of ring buffer size in memory
-            if (rest := sqnc.nbytes % self.ring_buffer_size.value) != 0:
-                rest = self.ring_buffer_size.value - rest
-                if rest % 2 != 0:
-                    raise MemoryError("Providet data array size is not a multiple of 2 bytes (size of one sample)")
-
-                fill_size = int((rest) / 2)
-                # The following line causes the an increase of memory consumption
-                sqnc = np.append(sqnc, np.zeros(fill_size, dtype=np.int16))
-                self.log.debug("Appended %s zeros to data array", fill_size)
-
         except Exception as exc:
             self.log.exception(exc, exc_info=True)
             raise exc
@@ -382,9 +329,24 @@ class TxCard(SpectrumDevice):
             >>> [c0_0, c1_0, c2_0, c3_0, c0_1, c1_1, c2_1, c3_1, ..., cX_N]
             Here, X denotes the channel and the subsequent index N the sample index.
         """
+        # Get total size of data buffer to be played out
+        self.data_buffer_size = data.nbytes
+        self.log.debug("Replay data buffer: %s bytes", self.data_buffer_size)
+
+        # >> Define software buffer
+        # Setup replay data buffer
+        data_buffer = data.ctypes.data_as(ctypes.POINTER(ctypes.c_int16))
+        # Allocate continuous ring buffer with minimimum necessary amount of memory
+        ring_buffer = create_dma_buffer(min(self.max_ring_buffer_size.value, self.data_buffer_size))
+
         try:
-            # Get total size of data buffer to be played out
-            self.data_buffer_size = int(data.nbytes)
+            # Check if ring buffer size is multiple of 2*num_ch (2 bytes per sample per channel)
+            if len(ring_buffer) % (self.num_ch * 2) != 0:
+                raise MemoryError(
+                    "Ring buffer size is not a multiple of channel sample product \
+                    (number of enables channels times 2 byte per sample)"
+                )
+            # Check size of data buffer
             if self.data_buffer_size % (self.num_ch * 2) != 0:
                 raise MemoryError(
                     "Replay data size is not a multiple of enabled channels times 2 (bytes per sample)..."
@@ -393,22 +355,25 @@ class TxCard(SpectrumDevice):
             self.log.exception(err, exc_info=True)
             raise err
 
-        self.log.debug("Replay data buffer: %s bytes", self.data_buffer_size)
+        # Set notify size to a 1/16 of max. buffer size
+        if self.max_ring_buffer_size.value % self.notify_rate == 0:
+            notify_size = spcm.int32(self.max_ring_buffer_size.value // self.notify_rate)
+        else:
+            # Set default fraktion to 16, notify size equals 1/16 of ring buffer size
+            notify_size = spcm.int32(self.max_ring_buffer_size.value // 16)
 
-        # >> Define software buffer
-        # Setup replay data buffer
-        data_buffer = data.ctypes.data_as(ctypes.POINTER(ctypes.c_int16))
-        # Allocate continuous ring buffer as defined by class attribute
-
-        # TODO: use something like min(self.ring_buffer_size.value, seq_size)
-        ring_buffer = create_dma_buffer(self.ring_buffer_size.value)
+        self.log.debug(
+            "Ring buffer size: %s; Notify size: %s",
+            self.max_ring_buffer_size.value,
+            notify_size.value,
+        )
 
         try:
             # Perform initial memory transfer: Fill the whole ring buffer
             if _ring_buffer_pos := ctypes.cast(ring_buffer, ctypes.c_void_p).value:
                 if _data_buffer_pos := ctypes.cast(data_buffer, ctypes.c_void_p).value:
-                    ctypes.memmove(_ring_buffer_pos, _data_buffer_pos, self.ring_buffer_size.value)
-                    transferred_bytes = self.ring_buffer_size.value
+                    ctypes.memmove(_ring_buffer_pos, _data_buffer_pos, len(ring_buffer))
+                    transferred_bytes = len(ring_buffer)
                 else:
                     raise RuntimeError("Could not get data buffer position")
             else:
@@ -422,29 +387,27 @@ class TxCard(SpectrumDevice):
             self.card,
             spcm.SPCM_BUF_DATA,
             spcm.SPCM_DIR_PCTOCARD,
-            self.notify_size,
+            notify_size,
             ring_buffer,
             spcm.uint64(0),
-            self.ring_buffer_size,
+            self.max_ring_buffer_size,
         )
-        spcm.spcm_dwSetParam_i64(self.card, spcm.SPC_DATA_AVAIL_CARD_LEN, self.ring_buffer_size)
+        self.handle_error(spcm.spcm_dwSetParam_i64(self.card, spcm.SPC_DATA_AVAIL_CARD_LEN, self.max_ring_buffer_size))
 
         self.log.debug("Starting card memory transfer")
-        error = spcm.spcm_dwSetParam_i32(
+        self.handle_error(spcm.spcm_dwSetParam_i32(
             self.card,
             spcm.SPC_M2CMD,
             spcm.M2CMD_DATA_STARTDMA | spcm.M2CMD_DATA_WAITDMA,
-        )
-        self.handle_error(error)
+        ))
 
         # Start card
         self.log.debug("Starting card operation")
-        error = spcm.spcm_dwSetParam_i32(
+        self.handle_error(spcm.spcm_dwSetParam_i32(
             self.card,
             spcm.SPC_M2CMD,
             spcm.M2CMD_CARD_START | spcm.M2CMD_CARD_ENABLETRIGGER,
-        )
-        self.handle_error(error)
+        ))
 
         avail_bytes = spcm.int32(0)
         usr_position = spcm.int32(0)
@@ -456,64 +419,38 @@ class TxCard(SpectrumDevice):
             spcm.spcm_dwGetParam_i32(self.card, spcm.SPC_DATA_AVAIL_USER_POS, ctypes.byref(usr_position))
 
             # Calculate new data for the transfer, when notify_size is available on continous buffer
-            if avail_bytes.value >= self.notify_size.value:
+            if avail_bytes.value >= notify_size.value:
                 transfer_count += 1
 
+                ring_buffer_position = ctypes.cast((
+                    ctypes.c_char * (self.max_ring_buffer_size.value - usr_position.value)).from_buffer(
+                        ring_buffer, usr_position.value), ctypes.c_void_p
+                    ).value
+
+                current_data_buffer = ctypes.cast(data_buffer, ctypes.c_void_p).value
+
                 # Get new buffer positions
-                if ring_buffer_position := ctypes.cast(
-                    (ctypes.c_char * (self.ring_buffer_size.value - usr_position.value)).from_buffer(
-                        ring_buffer, usr_position.value
-                    ),
-                    ctypes.c_void_p,
-                ).value:
-                    if current_data_buffer := ctypes.cast(data_buffer, ctypes.c_void_p).value:
-                        data_buffer_position = current_data_buffer + transferred_bytes
+                if ring_buffer_position and current_data_buffer:
+                    data_buffer_position = current_data_buffer + transferred_bytes
+                    # Calculate bytes to transfer, consider that remaining data might be less than notify size
+                    bytes_to_copy = min(self.data_buffer_size - transferred_bytes, notify_size.value)
 
-                        # Move memory: Current ring buffer position,
-                        # position in sequence data and amount to transfer (=> notify size)
-                        ctypes.memmove(
-                            ring_buffer_position,
-                            data_buffer_position,
-                            self.notify_size.value,
-                        )
+                    # TODO: Debug statement, to be removed...
+                    print(f"Transferring {bytes_to_copy} bytes to ring buffer...")
 
-                spcm.spcm_dwSetParam_i32(self.card, spcm.SPC_DATA_AVAIL_CARD_LEN, self.notify_size)
-                transferred_bytes += self.notify_size.value
+                    # Move memory: Current ring buffer position,
+                    # position in sequence data and amount to transfer (=> notify size)
+                    ctypes.memmove(
+                        ring_buffer_position,
+                        data_buffer_position,
+                        bytes_to_copy,
+                    )
 
-                error = spcm.spcm_dwSetParam_i32(self.card, spcm.SPC_M2CMD, spcm.M2CMD_DATA_WAITDMA)
-                self.handle_error(error)
+                    self.handle_error(
+                        spcm.spcm_dwSetParam_i32(self.card, spcm.SPC_DATA_AVAIL_CARD_LEN, spcm.uint32(bytes_to_copy))
+                    )
+                    transferred_bytes += bytes_to_copy
+
+                self.handle_error(spcm.spcm_dwSetParam_i32(self.card, spcm.SPC_M2CMD, spcm.M2CMD_DATA_WAITDMA))
 
         self.log.debug("Card operation stopped")
-
-    def get_status(self) -> int:
-        """Get the current card status.
-
-        Returns
-        -------
-            String with status description.
-        """
-        try:
-            if not self.card:
-                raise ConnectionError("No device found")
-        except ConnectionError as err:
-            self.log.exception(err, exc_info=True)
-            raise err
-        status = spcm.int32(0)
-        spcm.spcm_dwGetParam_i32(self.card, spcm.SPC_M2STATUS, ctypes.byref(status))
-        return status.value
-
-    def log_card_status(self, include_desc: bool = False) -> None:
-        """Log current card status.
-
-        The status is represented by a list. Each entry represents a possible card status in form
-        of a (sub-)list. It contains the status code, name and (optional) description of the spectrum
-        instrumentation manual.
-
-        Parameters
-        ----------
-        include_desc, optional
-            Flag which indicates if description string should be contained in status entry, by default False
-        """
-        msg, _ = translate_status(self.get_status(), include_desc=include_desc)
-        status = {key: val for val, key in msg.values()}
-        self.log.debug("Card status:\n%s", status)

--- a/src/console/spcm_control/tx_device.py
+++ b/src/console/spcm_control/tx_device.py
@@ -184,7 +184,7 @@ class TxCard(SpectrumDevice):
             ))
 
         self.log.debug("Device setup completed")
-        _ = self.get_status()
+        # _ = self.get_status()
 
     def set_gradient_offsets(self, offsets: Dimensions, high_impedance: list[bool] = [True, True, True]) -> None:
         """Set offset values of the gradient output channels.
@@ -390,9 +390,11 @@ class TxCard(SpectrumDevice):
             notify_size,
             ring_buffer,
             spcm.uint64(0),
-            self.max_ring_buffer_size,
+            # self.max_ring_buffer_size,
+            len(ring_buffer),
         )
-        self.handle_error(spcm.spcm_dwSetParam_i64(self.card, spcm.SPC_DATA_AVAIL_CARD_LEN, self.max_ring_buffer_size))
+        # self.handle_error(spcm.spcm_dwSetParam_i64(self.card, spcm.SPC_DATA_AVAIL_CARD_LEN, self.max_ring_buffer_size))
+        self.handle_error(spcm.spcm_dwSetParam_i64(self.card, spcm.SPC_DATA_AVAIL_CARD_LEN, len(ring_buffer)))
 
         self.log.debug("Starting card memory transfer")
         self.handle_error(spcm.spcm_dwSetParam_i32(

--- a/src/console/spcm_control/tx_device.py
+++ b/src/console/spcm_control/tx_device.py
@@ -321,6 +321,11 @@ class TxCard(SpectrumDevice):
             if not self.card:
                 raise ConnectionError("No connection to card established...")
 
+
+            # TODO: Get rid of the sequence extension here...
+            # TODO: Instead implement a function which transfers a notify size of data from the sequence, 
+            # and only fills the last tiny bit in the end if necessary
+
             # Extend the provided data array with zeros to obtain a multiple of ring buffer size in memory
             if (rest := sqnc.nbytes % self.ring_buffer_size.value) != 0:
                 rest = self.ring_buffer_size.value - rest
@@ -328,6 +333,7 @@ class TxCard(SpectrumDevice):
                     raise MemoryError("Providet data array size is not a multiple of 2 bytes (size of one sample)")
 
                 fill_size = int((rest) / 2)
+                # The following line causes the an increase of memory consumption
                 sqnc = np.append(sqnc, np.zeros(fill_size, dtype=np.int16))
                 self.log.debug("Appended %s zeros to data array", fill_size)
 
@@ -393,6 +399,8 @@ class TxCard(SpectrumDevice):
         # Setup replay data buffer
         data_buffer = data.ctypes.data_as(ctypes.POINTER(ctypes.c_int16))
         # Allocate continuous ring buffer as defined by class attribute
+
+        # TODO: use something like min(self.ring_buffer_size.value, seq_size)
         ring_buffer = create_dma_buffer(self.ring_buffer_size.value)
 
         try:

--- a/src/console/spcm_control/tx_device.py
+++ b/src/console/spcm_control/tx_device.py
@@ -332,12 +332,11 @@ class TxCard(SpectrumDevice):
         self.log.debug("Replay data buffer: %s bytes", self.data_buffer_size)
 
         # Calculate notify size is set to 1/16 of the replay buffer size
-        notify_size = min(
+        # Ensure that minimum notify size is 4096 bytes
+        notify_size = spcm.int32(max(4096, min(
             int(((self.data_buffer_size / self.notify_rate) // 4096) * 4096),
             int(((self.max_ring_buffer_size.value / self.notify_rate) // 4096) * 4096),
-        )
-        # Ensure that minimum notify size is 4096 bytes
-        notify_size = spcm.int32(max(notify_size, 4096))
+        )))
 
         # >> Define software buffer
         # Setup replay data buffer
@@ -385,7 +384,6 @@ class TxCard(SpectrumDevice):
         except RuntimeError as err:
             self.log.exception(err, exc_info=True)
             raise err
-
 
         # Perform initial data transfer to completely fill continuous buffer
         spcm.spcm_dwDefTransfer_i64(

--- a/src/console/spcm_control/tx_device.py
+++ b/src/console/spcm_control/tx_device.py
@@ -307,13 +307,11 @@ class TxCard(SpectrumDevice):
             self.is_running.set()
             self.worker.join()
 
-            error = spcm.spcm_dwSetParam_i32(
+            self.handle_error(spcm.spcm_dwSetParam_i32(
                 self.card,
                 spcm.SPC_M2CMD,
                 spcm.M2CMD_CARD_STOP | spcm.M2CMD_DATA_STOPDMA,
-            )
-
-            self.handle_error(error)
+            ))
             self.worker = None
         else:
             print("No active replay thread found...")
@@ -333,15 +331,26 @@ class TxCard(SpectrumDevice):
         self.data_buffer_size = data.nbytes
         self.log.debug("Replay data buffer: %s bytes", self.data_buffer_size)
 
+        # Calculate notify size is set to 1/16 of the replay buffer size
+        notify_size = min(
+            int(((self.data_buffer_size / self.notify_rate) // 4096) * 4096),
+            int(((self.max_ring_buffer_size.value / self.notify_rate) // 4096) * 4096),
+        )
+        # Ensure that minimum notify size is 4096 bytes
+        notify_size = spcm.int32(max(notify_size, 4096))
+
         # >> Define software buffer
         # Setup replay data buffer
         data_buffer = data.ctypes.data_as(ctypes.POINTER(ctypes.c_int16))
-        # Allocate continuous ring buffer with minimimum necessary amount of memory
-        ring_buffer = create_dma_buffer(min(self.max_ring_buffer_size.value, self.data_buffer_size))
+        # Allocate continuous ring buffer with minimimum necessary amount of memory, ensure multiple of notify size
+        min_ring_buffer_size = int(np.ceil(self.data_buffer_size / notify_size.value) * notify_size.value)
+        # Create page-aligned ring buffer
+        ring_buffer = create_dma_buffer(min(self.max_ring_buffer_size.value, min_ring_buffer_size))
+        ring_buffer_size = spcm.uint64(len(ring_buffer))
 
         try:
             # Check if ring buffer size is multiple of 2*num_ch (2 bytes per sample per channel)
-            if len(ring_buffer) % (self.num_ch * 2) != 0:
+            if ring_buffer_size.value % (self.num_ch * 2) != 0:
                 raise MemoryError(
                     "Ring buffer size is not a multiple of channel sample product \
                     (number of enables channels times 2 byte per sample)"
@@ -355,32 +364,28 @@ class TxCard(SpectrumDevice):
             self.log.exception(err, exc_info=True)
             raise err
 
-        # Set notify size to a 1/16 of max. buffer size
-        if self.max_ring_buffer_size.value % self.notify_rate == 0:
-            notify_size = spcm.int32(self.max_ring_buffer_size.value // self.notify_rate)
-        else:
-            # Set default fraktion to 16, notify size equals 1/16 of ring buffer size
-            notify_size = spcm.int32(self.max_ring_buffer_size.value // 16)
-
         self.log.debug(
             "Ring buffer size: %s; Notify size: %s",
-            self.max_ring_buffer_size.value,
+            ring_buffer_size.value,
             notify_size.value,
         )
 
         try:
             # Perform initial memory transfer: Fill the whole ring buffer
-            if _ring_buffer_pos := ctypes.cast(ring_buffer, ctypes.c_void_p).value:
-                if _data_buffer_pos := ctypes.cast(data_buffer, ctypes.c_void_p).value:
-                    ctypes.memmove(_ring_buffer_pos, _data_buffer_pos, len(ring_buffer))
-                    transferred_bytes = len(ring_buffer)
+            if (_ring_buffer_pos := ctypes.cast(ring_buffer, ctypes.c_void_p).value) and \
+                (_data_buffer_pos := ctypes.cast(data_buffer, ctypes.c_void_p).value):
+                if self.data_buffer_size < ring_buffer_size.value:
+                    ctypes.memmove(_ring_buffer_pos, _data_buffer_pos, self.data_buffer_size)
+                    transferred_bytes = self.data_buffer_size
                 else:
-                    raise RuntimeError("Could not get data buffer position")
+                    ctypes.memmove(_ring_buffer_pos, _data_buffer_pos, ring_buffer_size.value)
+                    transferred_bytes = ring_buffer_size.value
             else:
-                raise RuntimeError("Could not get ring buffer position")
+                raise RuntimeError("Could not get ring or data buffer position.")
         except RuntimeError as err:
             self.log.exception(err, exc_info=True)
             raise err
+
 
         # Perform initial data transfer to completely fill continuous buffer
         spcm.spcm_dwDefTransfer_i64(
@@ -390,11 +395,10 @@ class TxCard(SpectrumDevice):
             notify_size,
             ring_buffer,
             spcm.uint64(0),
-            # self.max_ring_buffer_size,
-            len(ring_buffer),
+            ring_buffer_size,
         )
-        # self.handle_error(spcm.spcm_dwSetParam_i64(self.card, spcm.SPC_DATA_AVAIL_CARD_LEN, self.max_ring_buffer_size))
-        self.handle_error(spcm.spcm_dwSetParam_i64(self.card, spcm.SPC_DATA_AVAIL_CARD_LEN, len(ring_buffer)))
+
+        self.handle_error(spcm.spcm_dwSetParam_i64(self.card, spcm.SPC_DATA_AVAIL_CARD_LEN, ring_buffer_size))
 
         self.log.debug("Starting card memory transfer")
         self.handle_error(spcm.spcm_dwSetParam_i32(
@@ -434,25 +438,33 @@ class TxCard(SpectrumDevice):
                 # Get new buffer positions
                 if ring_buffer_position and current_data_buffer:
                     data_buffer_position = current_data_buffer + transferred_bytes
-                    # Calculate bytes to transfer, consider that remaining data might be less than notify size
-                    bytes_to_copy = min(self.data_buffer_size - transferred_bytes, notify_size.value)
 
-                    # TODO: Debug statement, to be removed...
-                    print(f"Transferring {bytes_to_copy} bytes to ring buffer...")
-
-                    # Move memory: Current ring buffer position,
-                    # position in sequence data and amount to transfer (=> notify size)
-                    ctypes.memmove(
-                        ring_buffer_position,
-                        data_buffer_position,
-                        bytes_to_copy,
-                    )
+                    if (bytes_remaining := self.data_buffer_size - transferred_bytes) >= notify_size.value:
+                        # Enough data available -> copy notify size
+                        ctypes.memmove(
+                            ring_buffer_position,
+                            data_buffer_position,
+                            notify_size.value,
+                        )
+                    else:
+                        # Not enough data availabe -> set remaining bytes to zero
+                        ctypes.memmove(
+                            ring_buffer_position,
+                            data_buffer_position,
+                            bytes_remaining,
+                        )
+                        ctypes.memset(
+                            ring_buffer_position + bytes_remaining,
+                            0,
+                            notify_size.value - bytes_remaining,
+                        )
 
                     self.handle_error(
-                        spcm.spcm_dwSetParam_i32(self.card, spcm.SPC_DATA_AVAIL_CARD_LEN, spcm.uint32(bytes_to_copy))
+                        spcm.spcm_dwSetParam_i32(self.card, spcm.SPC_DATA_AVAIL_CARD_LEN, notify_size)
                     )
-                    transferred_bytes += bytes_to_copy
+                    transferred_bytes += notify_size.value
 
                 self.handle_error(spcm.spcm_dwSetParam_i32(self.card, spcm.SPC_M2CMD, spcm.M2CMD_DATA_WAITDMA))
 
+        self.handle_error(spcm.spcm_dwSetParam_i32(self.card, spcm.SPC_M2CMD, spcm.M2CMD_DATA_WAITDMA))
         self.log.debug("Card operation stopped")

--- a/src/console/utilities/ddc.py
+++ b/src/console/utilities/ddc.py
@@ -89,7 +89,7 @@ def filter_cic_fir_comp(signal, decimation, number_of_stages):
     ValueError
         Uneven decimation factor.
     """
-    cic_samples = 2 * (signal.shape[-1] // decimation)
+    cic_samples = int(2 * np.ceil(signal.shape[-1] / decimation))
     cic_decimation = signal.shape[-1] // cic_samples
 
     # CIC integrator Stages


### PR DESCRIPTION
So far, the transmit ring buffer was always set to the maximum.
To prevent any leftover bytes when transferring the sequence piecewise into the ring buffer,
the sequence was extended using `np.append()` to a multiple of the ring buffer size.
As explained in #64 

This PR fixes the issue by setting the ring buffer size to the minimum necessary,
the ring buffer is only really necessary if the sequence exceets the max. available ring buffer size.
When overwriting parts of the ring buffer by fractions of notify size, the size of the remaining data is checked.
If the remaining data is less then the notify size, only the remaining data is transferred.
This is usually the case for the very last transmit.