### PR TITLE
Demodulation and decimation fix

### DIFF
--- a/src/console/spcm_control/acquisition_control.py
+++ b/src/console/spcm_control/acquisition_control.py
@@ -325,7 +325,7 @@ class AcquisitionControl:
             print("Demodulation at freq.:", parameter.larmor_frequency)
 
             # Demodulation and decimation
-            data = data * np.exp(2j * np.pi * np.arange(data.shape[-1]) * parameter.larmor_frequency / self.f_spcm)
+            data = data * np.exp(-2j * np.pi * np.arange(data.shape[-1]) * parameter.larmor_frequency / self.f_spcm)
 
             # Switch case for DDC function
             match parameter.ddc_method:
@@ -335,7 +335,7 @@ class AcquisitionControl:
                     data = ddc.filter_moving_average(data, decimation=parameter.decimation, overlap=8)
                 case _:
                     # Default case is FIR decimation
-                    data = signal.decimate(data, q=parameter.decimation, ftype="fir")
+                    data = 2*signal.decimate(data, q=parameter.decimation, ftype="fir")
 
             # Correct for Rx phase
             data = data * np.exp(-1j * np.array(rx_phase_offset))[:, np.newaxis]

--- a/src/console/spcm_control/acquisition_control.py
+++ b/src/console/spcm_control/acquisition_control.py
@@ -335,7 +335,7 @@ class AcquisitionControl:
                     data = ddc.filter_moving_average(data, decimation=parameter.decimation, overlap=8)
                 case _:
                     # Default case is FIR decimation
-                    data = 2*signal.decimate(data, q=parameter.decimation, ftype="fir")
+                    data = 2 * signal.decimate(data, q=parameter.decimation, ftype="fir")
 
             # Correct for Rx phase
             data = data * np.exp(-1j * np.array(rx_phase_offset))[:, np.newaxis]


### PR DESCRIPTION
This PR fixes two things on the receive data processing:

1. The frequency of the demodulated data was inverted: if a 2.001 MHz signal was demodulated using a carrier frequency of 2 MHz the data output was at 1.999 MHz, and vice versa, see attached images. This is fixed by changing the sign on the demodulation exponent. Note that this fix means that any sequency which updates the larmor frequency will need to account for the inversion of the frequency axis.
![Current demodulation](https://github.com/user-attachments/assets/c70fbe9e-a41d-4f4d-a10c-64943622bdd8)
![Fixed demodulation](https://github.com/user-attachments/assets/c620c0ba-931e-4576-8ad7-42940106b302)

2. The decimated data is a factor of two smaller than the input data, this is expected, but it's preferable to keep the amplitude of the data the same before and after decimation,  so the decimated data (using the FIR decimation) is multiplied by 2 to correct for the scaling.

![Main branch - Raw vs Decimated](https://github.com/user-attachments/assets/fbba4a35-36c5-4d46-8799-de726ecbbb35)
![Fix - Raw vs Decimated](https://github.com/user-attachments/assets/fd05beec-e0b6-468b-b70c-0f7fb7e4b85d)
