### PR TITLE
Gradient delay fixed

### DIFF
--- a/src/console/pulseq_interpreter/sequence_provider.py
+++ b/src/console/pulseq_interpreter/sequence_provider.py
@@ -521,20 +521,29 @@ class SequenceProvider(Sequence):
                 waveform = self.calculate_gradient(
                     block=block.gx, fov_scaling=parameter.fov_scaling.x, offset=parameter.gradient_offset.x
                 )
+                delay = block.gx.delay
+                delay_samples = round(delay * self.spcm_freq)
+                waveform_start_gx = waveform_start + 4 * delay_samples
                 waveform_samples = np.size(waveform)
-                _seq[waveform_start + 1:waveform_start + 4 * waveform_samples + 1:4] = waveform
+                _seq[waveform_start_gx + 1:waveform_start_gx + 4 * waveform_samples + 1:4] = waveform
             if block.gy is not None:  # Gy event
                 waveform = self.calculate_gradient(
                     block=block.gy, fov_scaling=parameter.fov_scaling.y, offset=parameter.gradient_offset.y
                 )
+                delay = block.gy.delay
+                delay_samples = round(delay * self.spcm_freq)
+                waveform_start_gy = waveform_start + 4 * delay_samples
                 waveform_samples = np.size(waveform)
-                _seq[waveform_start + 2:waveform_start + 4 * waveform_samples + 2:4] = waveform
+                _seq[waveform_start_gy + 2:waveform_start_gy + 4 * waveform_samples + 2:4] = waveform
             if block.gz is not None:  # Gz event
                 waveform = self.calculate_gradient(
                     block=block.gz, fov_scaling=parameter.fov_scaling.z, offset=parameter.gradient_offset.z
                 )
+                delay = block.gz.delay
+                delay_samples = round(delay * self.spcm_freq)
+                waveform_start_gz = waveform_start + 4 * delay_samples
                 waveform_samples = np.size(waveform)
-                _seq[waveform_start + 3:waveform_start + 4 * waveform_samples + 3:4] = waveform
+                _seq[waveform_start_gz + 3:waveform_start_gz + 4 * waveform_samples + 3:4] = waveform
             if block.rf is not None:  # RF event
                 # Pre-calculated RF event size can be shorter than the duration of the block since it doesn't
                 # consider the post-pulse ring-down time. The RF waveform is placed at the start of the block


### PR DESCRIPTION
Delays on gradient channels were ignored in the unrolling of the sequence (see  #101) , this is fixed in this commit. See the X channel in the sequence below, it should be delayed 2 ms relative to the start of the ADC waveform but it happens concurrently. In this PR this is fixed, see the second image. 
![with delay - error](https://github.com/user-attachments/assets/0e5f1b63-abe8-4522-90b9-58cb06de0ea0)
![with delay - fix](https://github.com/user-attachments/assets/c7736774-6c66-4635-bc91-47f3a8d2d6fa)

The sequence in the plots is: [Delay_seq.txt](https://github.com/user-attachments/files/21038007/Delay_seq.txt)
