### PR TITLE
Fix pytest.yml

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Run pytest
         run: |
-          python -m pytest -n 4 --junitxml=pytest.xml --cov-report=term-missing:skip-covered --cov=console | tee pytest-coverage.txt
+          python -m pytest -n 4 --junitxml=pytest.xml --cov-report=term --cov=console | tee pytest-coverage.txt
 
       - name: Pytest coverage comment
         id: coverageComment


### PR DESCRIPTION
Fixes the error `Generating coverage report. Cannot read properties of null (reading 'missing')` in the pytest CI.