### PR TITLE
Fix unit of gpa_gain in exmaple device config

### DIFF
--- a/examples/example_device_config.yaml
+++ b/examples/example_device_config.yaml
@@ -60,5 +60,5 @@ SystemLimits:
   rf_raster_time: 5.e-8
   # Raster time for gradient waveforms.
   grad_raster_time: 5.e-8
-  # Raster time for ADC readout pulses.
+  # Raster time for ADC readout.
   adc_raster_time: 5.e-8


### PR DESCRIPTION
This PR fixes the unit of gpa_gain in example device config. In addition the example max_grad is scaled down to a realistic value (from 250 T/m to 40 mT/m) and descriptions from pulseq are added. 