### PR TITLE
Write image orientation to MRD file

### DIFF
--- a/src/console/interfaces/acquisition_data.py
+++ b/src/console/interfaces/acquisition_data.py
@@ -210,6 +210,7 @@ class AcquisitionData:
                 header=header,
                 sequence=self.sequence,
                 dataset_path=dataset_path,
+                channel_assignment=self.acquisition_parameters.channel_assignment.to_dict(),
             )
 
         log.warning("Invalid MRD header, could not write MRD file.")

--- a/src/console/interfaces/acquisition_data.py
+++ b/src/console/interfaces/acquisition_data.py
@@ -210,7 +210,7 @@ class AcquisitionData:
                 header=header,
                 sequence=self.sequence,
                 dataset_path=dataset_path,
-                channel_assignment=self.acquisition_parameters.channel_assignment.to_dict(),
+                channel_assignment=self.acquisition_parameters.channel_assignment,
             )
 
         log.warning("Invalid MRD header, could not write MRD file.")

--- a/src/console/utilities/data/write_acquisition_to_mrd.py
+++ b/src/console/utilities/data/write_acquisition_to_mrd.py
@@ -6,6 +6,7 @@ import ismrmrd
 import numpy as np
 from pypulseq.Sequence.sequence import Sequence
 
+from console.interfaces.dimensions import Dimensions
 from console.interfaces.rx_data import RxData
 from console.utilities.data import get_logger, mrd_helper
 
@@ -17,7 +18,7 @@ def write_acquisition_to_mrd(
     header: ismrmrd.xsd.ismrmrdHeader,
     sequence: Sequence,
     dataset_path: Path,
-    channel_assignment: dict[str, int | float],
+    channel_assignment: Dimensions,
 ) -> Path:
     """Write imaging data to ISMRMRD."""
     with ismrmrd.Dataset(dataset_path) as dataset:
@@ -27,12 +28,12 @@ def write_acquisition_to_mrd(
         acq = ismrmrd.Acquisition()
         acq.version = int(version("ismrmrd")[0])
 
-        # Set raw data orientation directions in LPS coordinates
+        # Set raw data orientation directions in LPS coordinates, assuming patient is lying supine, head first.
         # This information is shared for all acquisitions
         # The assumption is that the console output channels to physical gradient orientations are as follows
-        # ch output1 -> gradient along I to S
-        # ch output2 -> gradient along P to A
-        # ch output3 -> gradient along R to L
+        # ch output1 -> gradient from front to back (Patient: I to S)
+        # ch output2 -> gradient from top to bottom (Patient: P to A)
+        # ch output3 -> gradient from left to right (Patient: R to L)
         # For LPS coordinates the direction P to A needs to be inverted, i.e., read_dir = [0,-1,0]
 
         # Map logical gradient axes to physical directions in LPS coordinates
@@ -43,19 +44,16 @@ def write_acquisition_to_mrd(
         }
 
         # Set readout direction
-        if channel_assignment['x'] in direction_map:
-            idx, val = direction_map[int(channel_assignment['x'])]
-            acq.read_dir[idx] = val
+        idx, val = direction_map[int(channel_assignment.x)]
+        acq.read_dir[idx] = val
 
         # Set phase encoding direction
-        if channel_assignment['y'] in direction_map:
-            idx, val = direction_map[int(channel_assignment['y'])]
-            acq.phase_dir[idx] = val
+        idx, val = direction_map[int(channel_assignment.y)]
+        acq.phase_dir[idx] = val
 
         # Set slice direction
-        if channel_assignment['z'] in direction_map:
-            idx, val = direction_map[int(channel_assignment['z'])]
-            acq.slice_dir[idx] = val
+        idx, val = direction_map[int(channel_assignment.z)]
+        acq.slice_dir[idx] = val
 
         trajectory_position = 0
         none_counter = 0

--- a/src/console/utilities/data/write_acquisition_to_mrd.py
+++ b/src/console/utilities/data/write_acquisition_to_mrd.py
@@ -17,6 +17,7 @@ def write_acquisition_to_mrd(
     header: ismrmrd.xsd.ismrmrdHeader,
     sequence: Sequence,
     dataset_path: Path,
+    channel_assignment: dict[str, int | float],
 ) -> Path:
     """Write imaging data to ISMRMRD."""
     with ismrmrd.Dataset(dataset_path) as dataset:
@@ -25,9 +26,36 @@ def write_acquisition_to_mrd(
         # Create acquisition
         acq = ismrmrd.Acquisition()
         acq.version = int(version("ismrmrd")[0])
-        acq.read_dir[0] = 1.0
-        acq.phase_dir[1] = 1.0
-        acq.slice_dir[2] = 1.0
+
+        # Set raw data orientation directions in LPS coordinates
+        # This information is shared for all acquisitions
+        # The assumption is that the console output channels to physical gradient orientations are as follows
+        # ch output1 -> gradient along I to S
+        # ch output2 -> gradient along P to A
+        # ch output3 -> gradient along R to L
+        # For LPS coordinates the direction P to A needs to be inverted, i.e., read_dir = [0,-1,0]
+
+        # Map logical gradient axes to physical directions in LPS coordinates
+        direction_map = {
+            1: (2, 1.0),   # I to S -> [0, 0, 1]
+            2: (1, -1.0),  # P to A -> [0, -1, 0] (inverted for LPS)
+            3: (0, 1.0),   # R to L -> [1, 0, 0]
+        }
+
+        # Set readout direction
+        if channel_assignment['x'] in direction_map:
+            idx, val = direction_map[int(channel_assignment['x'])]
+            acq.read_dir[idx] = val
+
+        # Set phase encoding direction
+        if channel_assignment['y'] in direction_map:
+            idx, val = direction_map[int(channel_assignment['y'])]
+            acq.phase_dir[idx] = val
+
+        # Set slice direction
+        if channel_assignment['z'] in direction_map:
+            idx, val = direction_map[int(channel_assignment['z'])]
+            acq.slice_dir[idx] = val
 
         trajectory_position = 0
         none_counter = 0

--- a/tests/acquisition/test_ismrmrd.py
+++ b/tests/acquisition/test_ismrmrd.py
@@ -75,12 +75,15 @@ def test_write_single_acquisition_to_mrd(random_acquisition_data, num_coils: int
     header = ismrmrd.xsd.ismrmrdHeader()
     header.experimentalConditions = ismrmrd.xsd.experimentalConditionsType(receive_data[0].larmor_frequency)
 
+    channel_assignment = Dimensions(x=1, y=2, z=3)
+
     tmp_dir = tempfile.mkdtemp()
     mrd_path = write_acquisition_to_mrd(
         data=receive_data,
         header=header,
         dataset_path=Path(tmp_dir) / "raw_data.mrd",
         sequence=se_spectrum.constructor(num_samples=num_samples),
+        channel_assignment = channel_assignment,
     )
 
     with ismrmrd.File(mrd_path, 'r') as fh:


### PR DESCRIPTION
The raw_data/kspace orientation is based on the channel assignment for RO, PE1 and PE2 gradients of the PyPulseq sequence. This information is written to the MRD file, such that during later image reconstruction, the image can be properly saved to DICOM or Nifti using the correct orientation. 
A remaining issue might be that the implemented mapping from console channel to physical orientation depends on the cabling of the console and can vary between different setups. One could add the "console-channel - physical gradient" mapping to the system configuration "system_info" in https://github.com/schote/nexus-console/blob/4d84571e2c0302e3f68dc84d8013ec58c0da8104/src/console/interfaces/acquisition_data.py#L177
