### PR TITLE
Phase Correction of Acquisition Data

### DIFF
--- a/src/console/interfaces/rx_data.py
+++ b/src/console/interfaces/rx_data.py
@@ -117,8 +117,8 @@ class RxData:
         if self.phase_reference is not None and self.phase_ref_frequency is not None:
             time_reference = np.arange(self.phase_reference.size) * self.dwell_time_raw
             ref_demod = self.phase_reference * np.exp(-2j * np.pi * self.phase_ref_frequency * time_reference)
-            phase_correction = np.sum(ref_demod) * (self.demod_frequency / self.phase_ref_frequency)
-            data_demod *= np.exp(-1j * phase_correction[None, ...])
+            phase_correction = np.angle(np.sum(ref_demod)) * (self.demod_frequency / self.phase_ref_frequency)
+            data_demod *= np.exp(-1j * phase_correction)
 
         # Apply receive phase offset to data and return data
         return data_demod * np.exp(1j * self.phase_offset)

--- a/src/console/interfaces/rx_data.py
+++ b/src/console/interfaces/rx_data.py
@@ -51,6 +51,9 @@ class RxData:
     # Raw data is the raw data coming from the Rx cards, prior to demodulation and decimation
     # Shape of Raw data is (num_channels_enabled, raw number of samples)
     raw_data: None | np.ndarray = None
+    
+    # Phase reference signal
+    phase_reference: None | np.ndarray = None
 
     # Timestamp of start of data acquisition
     time_stamp: None | float = None

--- a/src/console/interfaces/rx_data.py
+++ b/src/console/interfaces/rx_data.py
@@ -49,7 +49,7 @@ class RxData:
     # Frequency in Hz with which the reference signal is demodulated
     phase_ref_frequency: float | None = None
 
-    # Set the default demod method to FIR
+    # Set the default demodulation method to FIR
     ddc_method: DDCMethod = DDCMethod.FIR
 
     # Scaling factor for each receive channel
@@ -65,7 +65,7 @@ class RxData:
     # Timestamp in s of start of data acquisition relative to sequence execution start
     time_stamp: None | float = None
 
-    # Proc data is the demodulated, phased and decimated data
+    # Processed data is the demodulated, phased and decimated data
     processed_data: None | np.ndarray = None
 
     def __post_init__(self) -> None:
@@ -146,7 +146,7 @@ class RxData:
             return data.astype(float)
 
     def process_data(self, store_unprocessed: bool = True) -> None:
-        """Proces (demodulate, phase and downsample) the raw data contained in the rx object."""
+        """Process (demodulate, phase and downsample) the raw data contained in the rx object."""
         if self.larmor_frequency is None:
             raise RuntimeError("Larmor frequency not set, please set prior to processing data")
 

--- a/src/console/interfaces/rx_data.py
+++ b/src/console/interfaces/rx_data.py
@@ -21,7 +21,7 @@ class RxData:
     num_samples_raw: int
     # Number of samples to be discarded before and after ADC, defined by dead time
     num_samples_discard: int
-    # Dwell time of decimated data in s 
+    # Dwell time of decimated data in s
     dwell_time: float
     # Dwell time of undecimated data in s
     dwell_time_raw: float
@@ -111,11 +111,11 @@ class RxData:
 
     def demod_and_phase_data(self, data) -> np.ndarray:
         """Demodulate and phase the data contained in raw_data.
-        
+
         This step first demodulates the acquired data using the demodulation frequency,
         which is usually the Larmor frequency. If a phase reference has been acquired,
         the phase reference signal is demodulated at the phase reference frequency.
-        The phase correction term calculated from the phase reference is used to correct the 
+        The phase correction term calculated from the phase reference is used to correct the
         acquired MR data. In a last step the phase offset defined by the sequence is applied.
         """
         if self.demod_frequency is None:

--- a/src/console/interfaces/rx_data.py
+++ b/src/console/interfaces/rx_data.py
@@ -15,15 +15,19 @@ class RxData:
     # Rx data event number
     index: int
 
-    # Data characteristics, defined by the ADC event in sequence definition
+    # Number of samples after decimation
     num_samples: int
+    # Number of raw samples before decimation
     num_samples_raw: int
-    num_samples_discard: int    # Number of samples to be discarded before and after ADC, defined by dead time
+    # Number of samples to be discarded before and after ADC, defined by dead time
+    num_samples_discard: int
+    # Dwell time of decimated data in s 
     dwell_time: float
+    # Dwell time of undecimated data in s
     dwell_time_raw: float
-
-    # Data offsets from sequence definition
+    # Phase offset from sequence definition in rad
     phase_offset: float
+    # Frequency offset from sequence definition in Hz
     freq_offset: float
 
     # Averages tracking
@@ -39,10 +43,10 @@ class RxData:
     # Set the larmor frequency in Hz for each object
     larmor_frequency: None | float = None
 
-    # Frequency with which the data are demodulated
+    # Frequency in Hz with which the data are demodulated
     demod_frequency: None | float = None
 
-    # Frequency with which the reference signal is demodulated
+    # Frequency in Hz with which the reference signal is demodulated
     phase_ref_frequency: float | None = None
 
     # Set the default demod method to FIR
@@ -58,7 +62,7 @@ class RxData:
     # Phase reference signal
     phase_reference: None | np.ndarray = None
 
-    # Timestamp of start of data acquisition
+    # Timestamp in s of start of data acquisition relative to sequence execution start
     time_stamp: None | float = None
 
     # Proc data is the demodulated, phased and decimated data
@@ -92,7 +96,7 @@ class RxData:
         return _dict
 
     def decimate_data(self, data) -> np.ndarray:
-        """Decimate the data using the passed method."""
+        """Decimate the data using the defined `DDCMethod` method."""
         if self.decimation_factor <= 1 or not isinstance(self.decimation_factor, int):
             raise ValueError(f"Invalid decimation factor {self.decimation_factor}")
 
@@ -106,7 +110,14 @@ class RxData:
                 return 2 * signal.decimate(data, q=self.decimation_factor, ftype="fir", axis=-1)
 
     def demod_and_phase_data(self, data) -> np.ndarray:
-        """Demodulate and phase the data contained in raw_data."""
+        """Demodulate and phase the data contained in raw_data.
+        
+        This step first demodulates the acquired data using the demodulation frequency,
+        which is usually the Larmor frequency. If a phase reference has been acquired,
+        the phase reference signal is demodulated at the phase reference frequency.
+        The phase correction term calculated from the phase reference is used to correct the 
+        acquired MR data. In a last step the phase offset defined by the sequence is applied.
+        """
         if self.demod_frequency is None:
             raise RuntimeError("Demodulation frequency not set")
         # Demodulate the data
@@ -115,9 +126,12 @@ class RxData:
 
         # Demodulate the reference signal if available and correct acquired data
         if self.phase_reference is not None and self.phase_ref_frequency is not None:
+            # Demodulation of the phase reference signal
             time_reference = np.arange(self.phase_reference.size) * self.dwell_time_raw
             ref_demod = self.phase_reference * np.exp(-2j * np.pi * self.phase_ref_frequency * time_reference)
+            # Calculation of the phase correction term for the acquired MR data
             phase_correction = np.angle(np.sum(ref_demod)) * (self.demod_frequency / self.phase_ref_frequency)
+            # Apply phase correction in place
             data_demod *= np.exp(-1j * phase_correction)
 
         # Apply receive phase offset to data and return data

--- a/src/console/interfaces/rx_data.py
+++ b/src/console/interfaces/rx_data.py
@@ -115,7 +115,7 @@ class RxData:
 
         # Demodulate the reference signal if available and correct acquired data
         if self.phase_reference is not None and self.phase_ref_frequency is not None:
-            time_reference = np.arange(self.phase_reference) * self.dwell_time_raw
+            time_reference = np.arange(self.phase_reference.size) * self.dwell_time_raw
             ref_demod = self.phase_reference * np.exp(-2j * np.pi * self.phase_ref_frequency * time_reference)
             phase_correction = np.sum(ref_demod) * (self.demod_frequency / self.phase_ref_frequency)
             data_demod *= np.exp(-1j * phase_correction[None, ...])

--- a/src/console/interfaces/rx_data.py
+++ b/src/console/interfaces/rx_data.py
@@ -42,6 +42,9 @@ class RxData:
     # Frequency with which the data are demodulated
     demod_frequency: None | float = None
 
+    # Frequency with which the reference signal is demodulated
+    phase_ref_frequency: float | None = None
+
     # Set the default demod method to FIR
     ddc_method: DDCMethod = DDCMethod.FIR
 
@@ -51,7 +54,7 @@ class RxData:
     # Raw data is the raw data coming from the Rx cards, prior to demodulation and decimation
     # Shape of Raw data is (num_channels_enabled, raw number of samples)
     raw_data: None | np.ndarray = None
-    
+
     # Phase reference signal
     phase_reference: None | np.ndarray = None
 
@@ -107,10 +110,17 @@ class RxData:
         if self.demod_frequency is None:
             raise RuntimeError("Demodulation frequency not set")
         # Demodulate the data
-        time_axis = np.arange(np.size(data, -1)) * self.dwell_time_raw
-        data_demod = data * np.exp(-2j * np.pi * time_axis * self.demod_frequency)
+        time = np.arange(np.size(data, -1)) * self.dwell_time_raw
+        data_demod = data * np.exp(-2j * np.pi * time * self.demod_frequency)
 
-        # Apply receive phase correction to data and return data
+        # Demodulate the reference signal if available and correct acquired data
+        if self.phase_reference is not None and self.phase_ref_frequency is not None:
+            time_reference = np.arange(self.phase_reference) * self.dwell_time_raw
+            ref_demod = self.phase_reference * np.exp(-2j * np.pi * self.phase_ref_frequency * time_reference)
+            phase_correction = np.sum(ref_demod) * (self.demod_frequency / self.phase_ref_frequency)
+            data_demod *= np.exp(-1j * phase_correction[None, ...])
+
+        # Apply receive phase offset to data and return data
         return data_demod * np.exp(1j * self.phase_offset)
 
     def scale_data(self, data) -> np.ndarray:
@@ -134,9 +144,7 @@ class RxData:
                              f"{np.size(self.raw_data, axis = -1)} collected vs {self.num_samples_raw} expected")
 
         self.demod_frequency = self.larmor_frequency + self.freq_offset
-
         scaled_data = self.scale_data(self.raw_data)
-
         demod_data = self.demod_and_phase_data(scaled_data)
 
         # Creating the processed data output array first and copying the values of the output of the decimation

--- a/src/console/pulseq_interpreter/sequence_provider.py
+++ b/src/console/pulseq_interpreter/sequence_provider.py
@@ -123,6 +123,16 @@ class SequenceProvider(Sequence):
             gradient_output_limits[1] if gradients_50ohms else int(2 * gradient_output_limits[1]),
             gradient_output_limits[2] if gradients_50ohms else int(2 * gradient_output_limits[2]),
         )
+        
+        # Setup phase reference signal
+        # TODO: Configure values in device configuration
+        _phase_reference_frequency = 1.2e6
+        _phase_reference_num_samples = 1000
+        _reference_signal = np.exp(2j*np.pi*(
+            _phase_reference_frequency*np.arange(_phase_reference_num_samples)*self.spcm_dwell_time
+        ))
+        self.phase_reference = np.zeros(_reference_signal.size, dtype=np.uint16)
+        self.phase_reference[_reference_signal > 0] = np.uint16(2**15)
 
     # -------- PyPulseq interface -------- #
 
@@ -414,10 +424,17 @@ class SequenceProvider(Sequence):
                 num_delay_samples = round(remaining_delay * self.spcm_freq)
 
                 adc_start = (block_pos[event_idx] + num_delay_samples) * 4
-                adc_end = (block_pos[event_idx] + num_delay_samples + num_samples_raw) * 4
+                adc_end = adc_start + num_samples_raw * 4
 
                 # Add ADC gate to 16th bit of output channel 1 (first gradient channel)
-                _seq[slice(adc_start + 1, adc_end + 1, 4)] |= np.uint16(2**15)
+                _seq[adc_start + 1:adc_end + 1:4] |= np.uint16(2**15)
+                
+                
+                # Add phase reference signal
+                num_samples_reference = min(num_samples_raw, self.phase_reference.size)
+                phase_ref_end = adc_start + num_samples_reference * 4
+                _seq[adc_start + 2:phase_ref_end + 2:4] |= self.phase_reference[:num_samples_reference]
+                
 
                 _rx_data.append(
                     RxData(

--- a/src/console/pulseq_interpreter/sequence_provider.py
+++ b/src/console/pulseq_interpreter/sequence_provider.py
@@ -29,6 +29,9 @@ except ImportError:
 INT16_MAX = np.iinfo(np.int16).max
 INT16_MIN = np.iinfo(np.int16).min
 
+NUM_REFERENCE_SAMPLES = 1000
+REFERENCE_FREQUENCY = 1.095e6
+
 
 @dataclass
 class ADCGate:
@@ -123,16 +126,12 @@ class SequenceProvider(Sequence):
             gradient_output_limits[1] if gradients_50ohms else int(2 * gradient_output_limits[1]),
             gradient_output_limits[2] if gradients_50ohms else int(2 * gradient_output_limits[2]),
         )
-        
+
         # Setup phase reference signal
-        # TODO: Configure values in device configuration
-        _phase_reference_frequency = 1.2e6
-        _phase_reference_num_samples = 1000
-        _reference_signal = np.exp(2j*np.pi*(
-            _phase_reference_frequency*np.arange(_phase_reference_num_samples)*self.spcm_dwell_time
-        ))
-        self.phase_reference = np.zeros(_reference_signal.size, dtype=np.uint16)
-        self.phase_reference[_reference_signal > 0] = np.uint16(2**15)
+        time = np.arange(NUM_REFERENCE_SAMPLES) * self.spcm_dwell_time
+        signal = np.exp(2j * np.pi * REFERENCE_FREQUENCY * time)
+        self.phase_reference = np.zeros(NUM_REFERENCE_SAMPLES, dtype=np.uint16)
+        self.phase_reference[signal > 0] = np.uint16(2**15)
 
     # -------- PyPulseq interface -------- #
 
@@ -428,13 +427,11 @@ class SequenceProvider(Sequence):
 
                 # Add ADC gate to 16th bit of output channel 1 (first gradient channel)
                 _seq[adc_start + 1:adc_end + 1:4] |= np.uint16(2**15)
-                
-                
+
                 # Add phase reference signal
                 num_samples_reference = min(num_samples_raw, self.phase_reference.size)
                 phase_ref_end = adc_start + num_samples_reference * 4
                 _seq[adc_start + 2:phase_ref_end + 2:4] |= self.phase_reference[:num_samples_reference]
-                
 
                 _rx_data.append(
                     RxData(
@@ -448,6 +445,7 @@ class SequenceProvider(Sequence):
                         freq_offset=block.adc.freq_offset,
                         total_averages=parameter.num_averages,
                         ddc_method=parameter.ddc_method,
+                        phase_ref_frequency=REFERENCE_FREQUENCY,
                         labels=labels,
                     )
                 )

--- a/src/console/spcm_control/rx_device.py
+++ b/src/console/spcm_control/rx_device.py
@@ -187,6 +187,10 @@ class RxCard(SpectrumDevice):
 
         # Digital filter setting for receiver, 0 = disable digital bandwidth filter
         sp.spcm_dwSetParam_i32(self.card, sp.SPC_DIGITALBWFILTER, 0)
+        
+        # Setup digital input channel for the phase reference signal
+        sp.spcm_dwSetParam_i32(self.card, sp.SPCM_X2_MODE, sp.SPCM_XMODE_DIGIN)
+        sp.spcm_dwSetParam_i32(self.card, sp.SPC_DIGMODE0, (sp.DIGMODEMASK_BIT15 & sp.SPCM_DIGMODE_X2))
 
         # Calculate trigger size depending on the number of active channels
         # Since data can only be gathered in notify size chunks, post_trigger // channel_count should be at least one
@@ -343,15 +347,15 @@ class RxCard(SpectrumDevice):
                 timestamp_1 = pll_data[int(available_timestamp_position.value / 8) + 2]
 
                 # Calculate gate duration and the number of adc gate sample points (per channel)
-                gate_sample = timestamp_1 - timestamp_0
-                gate_length = gate_sample / (self.sample_rate * 1e6)
+                num_gate_samples = timestamp_1 - timestamp_0
+                gate_duration = num_gate_samples / (self.sample_rate * 1e6)
 
                 self.log.info(
                     "Gate: (%s s, %s s); ADC duration: %s ms ; Samples/gate/channel: %s",
                     timestamp_0 / (self.sample_rate * 1e6),
                     timestamp_1 / (self.sample_rate * 1e6),
-                    float(gate_length) * 1e3,  # Can be trimmed.
-                    gate_sample,
+                    float(gate_duration) * 1e3,  # Can be trimmed.
+                    num_gate_samples,
                 )
 
                 # Tell buffer 32 bytes were read from timestamp buffer
@@ -362,10 +366,10 @@ class RxCard(SpectrumDevice):
 
                 # Calculate size of relevant data (pre_trigger needed to get position of start of gate)
                 # This is the minimum amount of data  must be available to get full gate data
-                total_bytes_gate = (gate_sample + self.pre_trigger) * 2 * self.num_channels.value
+                total_bytes_gate = (num_gate_samples + self.pre_trigger) * 2 * self.num_channels.value
                 # Get the total data duration, including post trigger, to accurately track buffer position
-                samples_sequence = (gate_sample + self.pre_trigger + self.post_trigger)
-                # Ensure data alignment
+                samples_sequence = (num_gate_samples + self.pre_trigger + self.post_trigger)
+                # Ensure data aligmment
                 alignment_samples = samples_sequence % self.gate_alignment
                 samples_sequence += alignment_samples
                 bytes_sequence = samples_sequence * 2 * self.num_channels.value
@@ -449,13 +453,12 @@ class RxCard(SpectrumDevice):
                         ptr_to_slice = cast(addressof(adc_data.contents) + byte_position, POINTER(c_short))
                         gate_data = np.ctypeslib.as_array(ptr_to_slice, ((total_bytes_gate // 2),))
 
-                    # Cut the pretrigger, we do not need it.
+                    # Cut the pretrigger (we don't need it) and reshape the data to (num_coils, num_samples)
                     pre_trigger_cut = (self.pre_trigger) * self.num_channels.value
-                    gate_data = gate_data[pre_trigger_cut:]
+                    gate_data = gate_data[pre_trigger_cut:].reshape((self.num_channels.value, num_gate_samples), order="F")
                     # Store raw data in RxData object
-                    self.rx_data[self._total_gates].raw_data = gate_data.reshape((self.num_channels.value,
-                                                                            gate_sample),
-                                                                            order="F").copy()
+                    self.rx_data[self._total_gates].raw_data = gate_data.copy() << 1
+                    self.rx_data[self._total_gates].phase_reference = (gate_data[0, 0:min(num_gate_samples, 1000)].astype(np.uint16) >> 15).copy()
                     self.rx_data[self._total_gates].scaling_factor = self.rx_scaling[:self.num_channels.value]
                     self.rx_data[self._total_gates].time_stamp = timestamp_0 / (self.sample_rate * 1e6)
 

--- a/src/console/spcm_control/rx_device.py
+++ b/src/console/spcm_control/rx_device.py
@@ -187,7 +187,7 @@ class RxCard(SpectrumDevice):
 
         # Digital filter setting for receiver, 0 = disable digital bandwidth filter
         sp.spcm_dwSetParam_i32(self.card, sp.SPC_DIGITALBWFILTER, 0)
-        
+
         # Setup digital input channel for the phase reference signal
         sp.spcm_dwSetParam_i32(self.card, sp.SPCM_X2_MODE, sp.SPCM_XMODE_DIGIN)
         sp.spcm_dwSetParam_i32(self.card, sp.SPC_DIGMODE0, (sp.DIGMODEMASK_BIT15 & sp.SPCM_DIGMODE_X2))
@@ -455,10 +455,15 @@ class RxCard(SpectrumDevice):
 
                     # Cut the pretrigger (we don't need it) and reshape the data to (num_coils, num_samples)
                     pre_trigger_cut = (self.pre_trigger) * self.num_channels.value
-                    gate_data = gate_data[pre_trigger_cut:].reshape((self.num_channels.value, num_gate_samples), order="F")
+                    gate_data = gate_data[pre_trigger_cut:].reshape(
+                        (self.num_channels.value, num_gate_samples),
+                        order="F",
+                    )
                     # Store raw data in RxData object
                     self.rx_data[self._total_gates].raw_data = gate_data.copy() << 1
-                    self.rx_data[self._total_gates].phase_reference = (gate_data[0, 0:min(num_gate_samples, 1000)].astype(np.uint16) >> 15).copy()
+                    self.rx_data[self._total_gates].phase_reference = (
+                        gate_data[0, 0:min(num_gate_samples, 1000)].astype(np.uint16) >> 15
+                    ).copy()
                     self.rx_data[self._total_gates].scaling_factor = self.rx_scaling[:self.num_channels.value]
                     self.rx_data[self._total_gates].time_stamp = timestamp_0 / (self.sample_rate * 1e6)
 

--- a/src/console/spcm_control/rx_device.py
+++ b/src/console/spcm_control/rx_device.py
@@ -369,7 +369,7 @@ class RxCard(SpectrumDevice):
                 total_bytes_gate = (num_gate_samples + self.pre_trigger) * 2 * self.num_channels.value
                 # Get the total data duration, including post trigger, to accurately track buffer position
                 samples_sequence = (num_gate_samples + self.pre_trigger + self.post_trigger)
-                # Ensure data aligmment
+                # Ensure data alignment
                 alignment_samples = samples_sequence % self.gate_alignment
                 samples_sequence += alignment_samples
                 bytes_sequence = samples_sequence * 2 * self.num_channels.value

--- a/src/console/spcm_control/rx_device.py
+++ b/src/console/spcm_control/rx_device.py
@@ -10,6 +10,7 @@ import numpy as np
 
 import console.spcm_control.spcm.pyspcm as sp
 from console.interfaces.rx_data import RxData
+from console.pulseq_interpreter.sequence_provider import NUM_REFERENCE_SAMPLES
 from console.spcm_control.abstract_device import SpectrumDevice
 from console.spcm_control.spcm.tools import create_dma_buffer, type_to_name
 
@@ -459,10 +460,10 @@ class RxCard(SpectrumDevice):
                         (self.num_channels.value, num_gate_samples),
                         order="F",
                     )
-                    # Store raw data in RxData object
+                    # Store raw data (15 bit) in RxData object, 16th is the digital phase reference
                     self.rx_data[self._total_gates].raw_data = gate_data.copy() << 1
                     self.rx_data[self._total_gates].phase_reference = (
-                        gate_data[0, 0:min(num_gate_samples, 1000)].astype(np.uint16) >> 15
+                        gate_data[0, 0:min(num_gate_samples, NUM_REFERENCE_SAMPLES)].astype(np.uint16) >> 15
                     ).copy()
                     self.rx_data[self._total_gates].scaling_factor = self.rx_scaling[:self.num_channels.value]
                     self.rx_data[self._total_gates].time_stamp = timestamp_0 / (self.sample_rate * 1e6)


### PR DESCRIPTION
### Problem
When repeating a simple spin echo experiment two groups with different starting phase can be observed.
To confirm this phase offset is caused by the measurement cards, a reference signal is generated and transferred at the beginning of each ADC gate. The observed phase offset of the MR signal is also clearly visible in the reference signal.

### Root
The transmit and the receive cards run synchronously by sharing the same clock. However, the ADC gate signal is transferred by a wired connection between the transmit and the receive card. Thus the physical ADC trigger is asynchronous. The phase shift in the reference signal is exactly 400ns what corresponds to 8 samples (at 20 MS/s). The receiver's trigger logic has to latch that asynchronous electrical pulse into its internal divided clock domain. If the physical trigger pulse arrives just slightly too late to meet the setup time for the current internal clock edge, the synchronization logic pushes it to the next clock cycle. Because the internal clock is processing data in 8-sample blocks, the observed 400ns phase shift can be observed.

### Solution
To correct for the observed phase shift, a predefined short phase reference signal (2000 samples @ 20 MS/s, 100us) is transferred at the beginning of each ADC gate. It is stored in the `RxData` object and used to compute the phase correction w.r.t. the MR signal.

<img width="1012" height="393" alt="image" src="https://github.com/user-attachments/assets/51ef7f92-2689-4468-b212-6ef15dca6e76" />

The plot shows the phase track of 50 spin echo signal acquisitions. The two groups of phase tracks contain 36 and 14 acquisitions. The left plot shows the raw phase of the demodulated MR signal. The right plot shows the corrected phase signals using the reference signal.