### PR TITLE
Use RF Block Definition for Calculation

### DIFF
--- a/src/console/pulseq_interpreter/sequence_provider.py
+++ b/src/console/pulseq_interpreter/sequence_provider.py
@@ -264,19 +264,6 @@ class SequenceProvider(Sequence):
 
         # Get list of all events and list of unique RF and ADC events, since they are frequently reused
         events_list = self.block_events
-
-        # Calculate rf pulse and unblanking waveforms from RF event
-        rf_events = [
-            (rf_pulse[0], Sequence.rf_from_lib_data(self, rf_pulse[1])) for rf_pulse in self.rf_library.data.items()
-        ]
-        rf_pulses = {}
-        for rf_event in rf_events:
-            rf_pulses[rf_event[0]] = self._calculate_rf(
-                block=rf_event[1],
-                b1_scaling=parameter.b1_scaling,
-                larmor_frequency=parameter.larmor_frequency,
-            )
-
         seq_duration, _, _ = self.duration()
         seq_samples = round(seq_duration * self.spcm_freq)
 
@@ -378,8 +365,11 @@ class SequenceProvider(Sequence):
                 # Pre-calculated RF event size can be shorter than the duration of the block since it doesn't
                 # consider the post-pulse ring-down time. The RF waveform is placed at the start of the block
                 # and the array is then sliced using the duration of the RF waveform to ensure a good fit
-                rf_waveform = rf_pulses[event[1]][0].real.astype(np.int16)
-                rf_unblanking = rf_pulses[event[1]][1]
+                rf_waveform, rf_unblanking = self._calculate_rf(
+                    block=block.rf,
+                    b1_scaling=parameter.b1_scaling,
+                    larmor_frequency=parameter.larmor_frequency,
+                )
 
                 rf_size = np.size(rf_waveform)  # Get size of the RF waveform
                 if rf_size > (block_pos[event_idx + 1] - block_pos[event_idx]):
@@ -391,7 +381,7 @@ class SequenceProvider(Sequence):
                 rf_end = (block_pos[event_idx] + rf_size) * 4
 
                 # Add RF waveform
-                _seq[rf_start:rf_end:4] = rf_waveform
+                _seq[rf_start:rf_end:4] = rf_waveform.real.astype(np.int16)
                 # Add unblanking signal to Z gradient
                 _seq[rf_start + 3:rf_end + 3:4] = _seq[rf_start + 3:rf_end + 3:4] | rf_unblanking
 

--- a/src/console/spcm_control/acquisition_control.py
+++ b/src/console/spcm_control/acquisition_control.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 import matplotlib as mpl
 import numpy as np
+from pypulseq import Opts
 
 from console.interfaces.acquisition_data import AcquisitionData
 from console.interfaces.acquisition_parameter import AcquisitionParameter
@@ -328,6 +329,10 @@ class AcquisitionControl:
     def get_device_configuration(self) -> NexusConfiguration:
         """Get nexus device configuration."""
         return self.config
+
+    def get_sequence_system(self) -> Opts:
+        """Get pypulseq sequence system from sequence provider."""
+        return self.seq_provider.system
 
     def post_processing(self, parameter: AcquisitionParameter) -> None:
         """Process acquired NMR data.

--- a/src/console/utilities/sequences/spectrometry/fid.py
+++ b/src/console/utilities/sequences/spectrometry/fid.py
@@ -40,7 +40,7 @@ def constructor(
     # Define RF pulse for excitation
     if use_sinc:
         rf_90 = pp.make_sinc_pulse(
-            system=system,
+            system=seq.system,
             flip_angle=flip_angle,
             duration=rf_duration,
             phase_offset=0,
@@ -49,7 +49,7 @@ def constructor(
         )
     else:
         rf_90 = pp.make_block_pulse(
-            system=system,
+            system=seq.system,
             flip_angle=flip_angle,
             duration=rf_duration,
             phase_offset=0,
@@ -61,12 +61,12 @@ def constructor(
         num_samples=num_samples,
         dwell=1 / acq_bandwidth,
         phase_offset=0,
-        system=system,
+        system=seq.system,
     )
 
     # Define delay to account for RF ringing
     ring_down_delay = pp.make_delay(
-        round((dead_time) / 1e-6) * 1e-6
+        round((dead_time) / 1e-6) * 1e-6,
     )
 
     seq.add_block(rf_90)

--- a/src/console/utilities/sequences/spectrometry/fid.py
+++ b/src/console/utilities/sequences/spectrometry/fid.py
@@ -3,7 +3,7 @@ from math import pi
 
 import pypulseq as pp
 
-from console.utilities.sequences.system_settings import system
+from console.utilities.sequences.system_settings import system as default_system
 
 
 def constructor(
@@ -14,6 +14,7 @@ def constructor(
     use_sinc: bool = False,
     time_bw_product: float = 4,
     flip_angle: float = pi / 2,
+    system: pp.Opts | None = None,
     ) -> pp.Sequence:
     """Construct FID sequence.
 
@@ -33,7 +34,7 @@ def constructor(
     ValueError
         Sequence timing check failed
     """
-    seq = pp.Sequence(system=system)
+    seq = pp.Sequence(system=system) if system is not None else pp.Sequence(system=default_system)
     seq.set_definition("Name", "fid")
 
     # Define RF pulse for excitation
@@ -44,7 +45,7 @@ def constructor(
             duration=rf_duration,
             phase_offset=0,
             time_bw_product=time_bw_product,
-            delay=system.rf_dead_time,
+            delay=seq.system.rf_dead_time,
         )
     else:
         rf_90 = pp.make_block_pulse(
@@ -52,7 +53,7 @@ def constructor(
             flip_angle=flip_angle,
             duration=rf_duration,
             phase_offset=0,
-            delay=system.rf_dead_time,
+            delay=seq.system.rf_dead_time,
         )
 
     # Define ADC event

--- a/src/console/utilities/sequences/spectrometry/fid.py
+++ b/src/console/utilities/sequences/spectrometry/fid.py
@@ -8,52 +8,56 @@ from console.utilities.sequences.system_settings import system as default_system
 
 def constructor(
     rf_duration: float = 200e-6,
-    dead_time: float = 2e-3,
     num_samples: int = 256,
     acq_bandwidth: float | int = 20e3,
     use_sinc: bool = False,
     time_bw_product: float = 4,
     flip_angle: float = pi / 2,
-    system: pp.Opts | None = None,
+    system: pp.Opts = default_system,
     ) -> pp.Sequence:
     """Construct FID sequence.
 
     Parameters
     ----------
     rf_duration, optional
-        RF duration in s, by default 400e-6
+        RF duration in s, by default 200e-6
+    num_samples, optional
+        Number of ADC sample points, by default 256
+    acq_bandwidth, optional
+        Acquisition bandwidth in Hz, by default 20e3
     use_sinc, optional
-        RF pulse type, if true sinc pulse is used, rect otherwise, by default True
+        If set, sinc RF pulse is used, otherwise block pulse, by default False
+    time_bw_product, optional
+        Time bandwidth product, by default 4
+    flip_angle, optional
+        Flip angle of RF pulse, by default pi/2
+    system, optional
+        Sequence system to be used for sequence construction, by default default_system
 
     Returns
     -------
         Pypulseq ``Sequence`` instance
-
-    Raises
-    ------
-    ValueError
-        Sequence timing check failed
     """
-    seq = pp.Sequence(system=system) if system is not None else pp.Sequence(system=default_system)
+    seq = pp.Sequence(system=system)
     seq.set_definition("Name", "fid")
 
     # Define RF pulse for excitation
     if use_sinc:
         rf_90 = pp.make_sinc_pulse(
-            system=seq.system,
+            system=system,
             flip_angle=flip_angle,
             duration=rf_duration,
             phase_offset=0,
             time_bw_product=time_bw_product,
-            delay=seq.system.rf_dead_time,
+            delay=system.rf_dead_time,
         )
     else:
         rf_90 = pp.make_block_pulse(
-            system=seq.system,
+            system=system,
             flip_angle=flip_angle,
             duration=rf_duration,
             phase_offset=0,
-            delay=seq.system.rf_dead_time,
+            delay=system.rf_dead_time,
         )
 
     # Define ADC event
@@ -61,16 +65,10 @@ def constructor(
         num_samples=num_samples,
         dwell=1 / acq_bandwidth,
         phase_offset=0,
-        system=seq.system,
-    )
-
-    # Define delay to account for RF ringing
-    ring_down_delay = pp.make_delay(
-        round((dead_time) / 1e-6) * 1e-6,
+        system=system,
     )
 
     seq.add_block(rf_90)
-    seq.add_block(ring_down_delay)
     seq.add_block(adc)
 
     return seq

--- a/src/console/utilities/sequences/spectrometry/se_spectrum.py
+++ b/src/console/utilities/sequences/spectrometry/se_spectrum.py
@@ -14,7 +14,8 @@ def constructor(
     use_sinc: bool = False,
     time_bw_product: float = 4,
     use_fid: bool = True,
-    ) -> pp.Sequence:
+    sys: pp.Opts | None = None,
+) -> pp.Sequence:
     """Construct spin echo spectrum sequence.
 
     Parameters
@@ -43,7 +44,7 @@ def constructor(
     ValueError
         Sequence timing check failed
     """
-    seq = pp.Sequence(system=system)
+    seq = pp.Sequence(system=sys) if sys is not None else pp.Sequence(system=system)
 
     if use_fid:
         seq.set_definition("Name", "se_decay_spectrum")

--- a/src/console/utilities/sequences/spectrometry/se_spectrum.py
+++ b/src/console/utilities/sequences/spectrometry/se_spectrum.py
@@ -55,38 +55,60 @@ def constructor(
     # Define RF pulses for excitation and refocusing
     if use_sinc:
         rf_90 = pp.make_sinc_pulse(
-            system=system, flip_angle=pi / 2, phase_offset=0, duration=rf_duration, time_bw_product=time_bw_product,
-            delay=system.rf_dead_time
+            system=seq.system,
+            flip_angle=pi / 2,
+            phase_offset=0,
+            duration=rf_duration,
+            time_bw_product=time_bw_product,
+            delay=seq.system.rf_dead_time,
         )
         rf_180 = pp.make_sinc_pulse(
-            system=system, flip_angle=pi, phase_offset=pi / 2, duration=rf_duration, time_bw_product=time_bw_product,
-            delay=system.rf_dead_time
+            system=seq.system,
+            flip_angle=pi,
+            phase_offset=pi / 2,
+            duration=rf_duration,
+            time_bw_product=time_bw_product,
+            delay=seq.system.rf_dead_time,
         )
     else:
-        rf_90 = pp.make_block_pulse(system=system, flip_angle=pi / 2, phase_offset=0, duration=rf_duration,
-                                    delay=system.rf_dead_time)
-        rf_180 = pp.make_block_pulse(system=system, flip_angle=pi, phase_offset=pi / 2, duration=rf_duration,
-                                     delay=system.rf_dead_time)
+        rf_90 = pp.make_block_pulse(
+            system=seq.system,
+            flip_angle=pi / 2,
+            phase_offset=0,
+            duration=rf_duration,
+            delay=seq.system.rf_dead_time,
+        )
+        rf_180 = pp.make_block_pulse(
+            system=seq.system,
+            flip_angle=pi,
+            phase_offset=pi / 2,
+            duration=rf_duration,
+            delay=seq.system.rf_dead_time,
+        )
     # Define ADC duration
-    adc_duration = raster(val=num_samples / acq_bandwidth, precision=system.adc_raster_time)
+    adc_duration = raster(val=num_samples / acq_bandwidth, precision=seq.system.adc_raster_time)
 
     # Define ADC event
     adc = pp.make_adc(
         num_samples=num_samples,
         duration=adc_duration,
-        system=system,
+        system=seq.system,
     )
 
     # Calculate delays to achieve desired echo time
-    te_delay_1 = raster(echo_time / 2 - rf_duration - rf_90.ringdown_time - rf_180.delay,
-                        system.grad_raster_time)
+    te_delay_1 = raster(
+        echo_time / 2 - rf_duration - rf_90.ringdown_time - rf_180.delay,
+        seq.system.grad_raster_time,
+    )
     if use_fid:
-        te_delay_2 = raster(echo_time / 2 - rf_duration / 2 - rf_180.ringdown_time - adc.dead_time,
-                            system.grad_raster_time)
+        te_delay_2 = raster(
+            echo_time / 2 - rf_duration / 2 - rf_180.ringdown_time - adc.dead_time,
+            seq.system.grad_raster_time,
+        )
     else:
         te_delay_2 = raster(
             echo_time / 2 - rf_duration / 2 - adc_duration / 2 - rf_180.ringdown_time - adc.dead_time,
-            system.grad_raster_time
+            seq.system.grad_raster_time,
         )
 
     seq.add_block(rf_90)

--- a/src/console/utilities/sequences/spectrometry/se_spectrum.py
+++ b/src/console/utilities/sequences/spectrometry/se_spectrum.py
@@ -3,7 +3,8 @@ from math import pi
 
 import pypulseq as pp
 
-from console.utilities.sequences.system_settings import raster, system
+from console.utilities.sequences.system_settings import raster
+from console.utilities.sequences.system_settings import system as default_system
 
 
 def constructor(
@@ -14,7 +15,7 @@ def constructor(
     use_sinc: bool = False,
     time_bw_product: float = 4,
     use_fid: bool = True,
-    sys: pp.Opts | None = None,
+    system: pp.Opts | None = None,
 ) -> pp.Sequence:
     """Construct spin echo spectrum sequence.
 
@@ -44,7 +45,7 @@ def constructor(
     ValueError
         Sequence timing check failed
     """
-    seq = pp.Sequence(system=sys) if sys is not None else pp.Sequence(system=system)
+    seq = pp.Sequence(system=system) if system is not None else pp.Sequence(system=default_system)
 
     if use_fid:
         seq.set_definition("Name", "se_decay_spectrum")


### PR DESCRIPTION
Similar to #153 this PR updates the RF calculation. Instead of pre-calculating the RF waveforms from the library definitions, we now rely on the block definitions. Pypulseq 1.5.X adds variables to the RF event definition in the library, which were accessed by fixed list indices. Using the block definitions leads to some overhead but ensures save attribute access.   