### PR TITLE
Revision of the System Settings Usage

### DIFF
--- a/src/console/interfaces/device_configuration.py
+++ b/src/console/interfaces/device_configuration.py
@@ -1,15 +1,16 @@
 """Implementation of the device configuration models."""
-from typing import Annotated
+from typing import Annotated, Literal
 
 from pydantic import BaseModel, Field, model_validator
 from pypulseq import Opts
 
-# Ensure that max. amplitude is within 1 and 6000 mV.
-# Limits may depend on specific configuration of spectrum cards.
-AmplitudeInt = Annotated[int, Field(ge=1, le=6000)]
+# Ensure that max. amplitude is within 1 and 6000 mV (step size 1 mV).
+# Limits depend on card version.
+TxAmplitudeType = Annotated[int, Field(ge=1, le=6000)]
+# RX amplitude must be one of 200, 500, 1000, 2000, 5000 or 10000 (in mV), depends on card version.
+RxAmplitudeType = Literal[200, 500, 1000, 2000, 5000, 10000]
 # Ensure valid filter type, channel filter type must be 0, 1, 2 or 3.
-# See spectrum instrumentation manual for reference.
-# This may depend on the specific card configuration.
+# See spectrum instrumentation manual for reference, depends on card version.
 FilterTypeInt = Annotated[int, Field(ge=0, le=3)]
 
 class TxConfiguration(BaseModel):
@@ -19,7 +20,7 @@ class TxConfiguration(BaseModel):
 
     device_path: str = Field(..., strict=True)
     sampling_rate: int = Field(..., strict=True)
-    channel_max_amplitude: tuple[AmplitudeInt, AmplitudeInt, AmplitudeInt, AmplitudeInt] = Field(...)
+    channel_max_amplitude: tuple[TxAmplitudeType, TxAmplitudeType, TxAmplitudeType, TxAmplitudeType] = Field(...)
     channel_filter_type: tuple[FilterTypeInt, FilterTypeInt, FilterTypeInt, FilterTypeInt] = Field(...)
     rf_terminated_50ohm: bool = Field(..., strict=True)
     gradients_terminated_50ohm: bool = Field(..., strict=True)
@@ -37,7 +38,7 @@ class RxConfiguration(BaseModel):
     sampling_rate: int = Field(..., strict=True)
     max_available_channels: int = Field(..., strict=True)
     channel_enable: tuple[bool, ...] = Field(...)
-    channel_max_amplitude: tuple[AmplitudeInt, ...] = Field(...)
+    channel_max_amplitude: tuple[RxAmplitudeType, ...] = Field(...)
     channel_terminated_50ohm: tuple[bool, ...] = Field(...)
 
     @model_validator(mode="after")
@@ -72,15 +73,16 @@ class SystemLimits(BaseModel):
 
     model_config = {"extra": "ignore"}  # Ignore unknown fields instead of raising an error
 
-    max_grad: float = Field(..., strict=True)
-    max_slew: float = Field(..., strict=True)
-    rf_dead_time: float = Field(..., strict=True)
-    rf_ringdown_time: float = Field(..., strict=True)
-    adc_dead_time: float = Field(..., strict=True)
-    block_duration_raster: float = Field(..., strict=True)
-    rf_raster_time: float = Field(..., strict=True)
-    grad_raster_time: float = Field(..., strict=True)
-    adc_raster_time: float = Field(..., strict=True)
+    max_grad: float = Field(..., strict=True, gt=0)
+    max_slew: float = Field(..., strict=True, gt=0)
+    rf_dead_time: float = Field(..., strict=True, ge=0)
+    rf_ringdown_time: float = Field(..., strict=True, ge=0)
+    adc_dead_time: float = Field(..., strict=True, ge=0)
+    block_duration_raster: float = Field(..., strict=True, gt=0)
+    rf_raster_time: float = Field(..., strict=True, ge=0)
+    grad_raster_time: float = Field(..., strict=True, gt=0)
+    adc_raster_time: float = Field(..., strict=True, gt=0)
+    B0: float = Field(default=50e-3, strict=True, gt=0)
 
     def get_opts(self) -> Opts:
         """Return system limits of the MR scanner as PyPulseq `Opts` object."""
@@ -96,6 +98,7 @@ class SystemLimits(BaseModel):
             rf_raster_time=self.rf_raster_time,
             grad_raster_time=self.grad_raster_time,
             adc_raster_time=self.adc_raster_time,
+            B0=self.B0
         )
 
 

--- a/src/console/interfaces/device_configuration.py
+++ b/src/console/interfaces/device_configuration.py
@@ -1,6 +1,7 @@
 """Implementation of the device configuration models."""
 from typing import Annotated
 
+from pypulseq import Opts
 from pydantic import BaseModel, Field, model_validator
 
 # Ensure that max. amplitude is within 1 and 6000 mV.
@@ -80,6 +81,21 @@ class SystemLimits(BaseModel):
     rf_raster_time: float = Field(..., strict=True)
     grad_raster_time: float = Field(..., strict=True)
     adc_raster_time: float = Field(..., strict=True)
+    
+    def get_opts(self) -> Opts:
+        return Opts(
+            max_grad=self.max_grad,
+            max_slew=self.max_slew,
+            grad_unit="Hz/m",
+            slew_unit="Hz/m/s",
+            rf_dead_time=self.rf_dead_time,
+            rf_ringdown_time=self.rf_ringdown_time,
+            adc_dead_time=self.adc_dead_time,
+            block_duration_raster=self.block_duration_raster,
+            rf_raster_time=self.rf_raster_time,
+            grad_raster_time=self.grad_raster_time,
+            adc_raster_time=self.adc_raster_time
+        )
 
 
 class NexusConfiguration(BaseModel):

--- a/src/console/interfaces/device_configuration.py
+++ b/src/console/interfaces/device_configuration.py
@@ -1,8 +1,8 @@
 """Implementation of the device configuration models."""
 from typing import Annotated
 
-from pypulseq import Opts
 from pydantic import BaseModel, Field, model_validator
+from pypulseq import Opts
 
 # Ensure that max. amplitude is within 1 and 6000 mV.
 # Limits may depend on specific configuration of spectrum cards.
@@ -81,8 +81,9 @@ class SystemLimits(BaseModel):
     rf_raster_time: float = Field(..., strict=True)
     grad_raster_time: float = Field(..., strict=True)
     adc_raster_time: float = Field(..., strict=True)
-    
+
     def get_opts(self) -> Opts:
+        """Return system limits of the MR scanner as PyPulseq `Opts` object."""
         return Opts(
             max_grad=self.max_grad,
             max_slew=self.max_slew,
@@ -94,7 +95,7 @@ class SystemLimits(BaseModel):
             block_duration_raster=self.block_duration_raster,
             rf_raster_time=self.rf_raster_time,
             grad_raster_time=self.grad_raster_time,
-            adc_raster_time=self.adc_raster_time
+            adc_raster_time=self.adc_raster_time,
         )
 
 

--- a/src/console/pulseq_interpreter/sequence_provider.py
+++ b/src/console/pulseq_interpreter/sequence_provider.py
@@ -13,7 +13,6 @@ from pypulseq.Sequence.sequence import Sequence
 from scipy.signal import resample
 
 from console.interfaces.acquisition_parameter import AcquisitionParameter
-from console.interfaces.device_configuration import SystemLimits
 from console.interfaces.dimensions import Dimensions
 from console.interfaces.rx_data import RxData
 from console.interfaces.unrolled_sequence import UnrolledSequence
@@ -67,7 +66,7 @@ class SequenceProvider(Sequence):
         rf_50ohms: bool,
         rf_to_mvolt: float,
         spcm_dwell_time: float,
-        system_limits: SystemLimits,
+        system: Opts,
     ):
         """Initialize sequence provider class which is used to unroll a pulseq sequence.
 
@@ -95,21 +94,13 @@ class SequenceProvider(Sequence):
             Absolute maximum system limits defined in the device configuration.
             Used to instantiate the pypulseq `Opts()` class.
         """
-        super().__init__(
-            system=Opts(
-                **system_limits.model_dump(),
-                B0=50e-3,
-                grad_unit="Hz/m",   # system limit is defined in this units
-                slew_unit="Hz/m/s",  # system limit is defined in this units
-            ),
-        )
+        super().__init__(system=system)
         self.log = logging.getLogger("SeqProv")
 
         # Set class instance attributes
         self.rf_to_mvolt = rf_to_mvolt
         self.spcm_dwell_time = spcm_dwell_time
         self.spcm_freq = 1 / spcm_dwell_time
-        self.system_limits = system_limits
         self.gpa_gain = gpa_gain
         self.grad_eff = gradient_efficiency
 
@@ -127,10 +118,7 @@ class SequenceProvider(Sequence):
     # -------- PyPulseq interface -------- #
 
     def from_pypulseq(self, seq: Sequence) -> None:
-        """Cast a pypulseq ``Sequence`` instance to this ``SequenceProvider``.
-
-        If argument is a valid ``Sequence`` instance, all the attributes of
-        ``Sequence`` are set in this ``SequenceProvider`` (inherits from ``Sequence``).
+        """Read a pypulseq sequence to sequence provider.
 
         Parameters
         ----------
@@ -139,57 +127,24 @@ class SequenceProvider(Sequence):
 
         Raises
         ------
-        ValueError
-            seq is not a valid pypulseq ``Sequence`` instance
         AttributeError
-            Key of Sequence instance not
+            seq is not a valid pypulseq ``Sequence`` instance
         """
-        try:
-            # List of (attribute, comparison function, message operator symbol) to check system limits
-            limits = [
-                ("max_grad", operator.gt, "<="),
-                ("max_slew", operator.gt, "<="),
-                ("grad_raster_time", operator.lt, ">="),
-                ("adc_raster_time", operator.lt, ">="),
-                ("rf_raster_time", operator.lt, ">="),
-                ("block_duration_raster", operator.lt, ">="),
-                ("adc_dead_time", operator.lt, ">="),
-                ("rf_dead_time", operator.lt, ">="),
-                ("rf_ringdown_time", operator.lt, ">="),
-            ]
-            errors = []
-            for attr, compare, symbol in limits:
-                limit_val = getattr(self.system_limits, attr)
-                # Compare can be done without converting gradient/slew-rate values
-                # -> internally stored in Hz/m and Hz/m/s
-                if compare(system_value := getattr(seq.system, attr), limit_val):
-                    errors.append(f"{attr} out of bounds (limit {symbol} {limit_val}) (system value: {system_value})")
-            if errors:
-                raise ValueError("; ".join(errors))
-
-            if not isinstance(seq, Sequence):
-                raise ValueError("Provided object is not an instance of pypulseq Sequence")
-            for key, value in seq.__dict__.items():
-                # Check if attribute exists
-                if not hasattr(self, key):   # dont't overwrite system
-                    # raise AttributeError("Attribute %s not found in SequenceProvider" % key)
-                    continue
-                # Set attribute
-                setattr(self, key, value)
-        except (ValueError, AttributeError) as exc:
-            self.log.exception("Could not set sequence: %s" % exc, exc_info=True)
-            raise exc
+        if not isinstance(seq, Sequence):
+            raise AttributeError("Invalid sequence.")
+        for block_index, _ in seq.block_events.items():
+            block = seq.get_block(block_index)
+            self.add_block(block)
+        # Set definitions
+        self.definitions = seq.definitions
 
     def to_pypulseq(self) -> Sequence | None:
-        """Slice sequence provider to return pypulseq sequence."""
-        seq = Sequence()
-        try:
-            for key, value in vars(self).items():
-                if hasattr(seq, key):
-                    setattr(seq, key, value)
-        except Exception as exc:
-            self.log.error("Could not slice pypulseq sequence from sequence provider.", exc_info=exc)
-            return None
+        """Create a pypulseq sequence from sequence provider."""
+        seq = Sequence(system=self.system)
+        for block_index, _ in self.block_events.items():
+            block = self.get_block(block_index)
+            seq.add_block(block)
+        seq.definitions = self.definitions
         return seq
 
     # -------- Public interface -------- #

--- a/src/console/pulseq_interpreter/sequence_provider.py
+++ b/src/console/pulseq_interpreter/sequence_provider.py
@@ -93,6 +93,8 @@ class SequenceProvider(Sequence):
             Absolute maximum system limits defined in the device configuration.
             Used to instantiate the pypulseq `Opts()` class.
         """
+        if not isinstance(system, Opts):
+            raise AttributeError("Invalid system: Pypulseq `Opts` definition required.")
         super().__init__(system=system)
         self.log = logging.getLogger("SeqProv")
 

--- a/src/console/pulseq_interpreter/sequence_provider.py
+++ b/src/console/pulseq_interpreter/sequence_provider.py
@@ -1,6 +1,5 @@
 """Sequence provider class."""
 import logging
-import operator
 from collections.abc import Callable
 from dataclasses import dataclass
 from math import floor

--- a/src/console/pulseq_interpreter/sequence_provider.py
+++ b/src/console/pulseq_interpreter/sequence_provider.py
@@ -131,6 +131,8 @@ class SequenceProvider(Sequence):
         """
         if not isinstance(seq, Sequence):
             raise AttributeError("Invalid sequence.")
+        # Re-initialize the parent to start from a clean pypulseq sequence
+        super().__init__(system=self.system)
         for block_index, _ in seq.block_events.items():
             block = seq.get_block(block_index)
             self.add_block(block)

--- a/src/console/spcm_control/acquisition_control.py
+++ b/src/console/spcm_control/acquisition_control.py
@@ -73,8 +73,6 @@ class AcquisitionControl:
         self.log = logging.getLogger("AcqCtrl")
         self.log.info("--- Acquisition control started\n")
 
-        # Load device configuration and create instances
-        # TODO: Generalize Nexus configuration to allow different setups
         self.config: NexusConfiguration = load_nexus_config(configuration_file)
         # Create sequence provider instance
         self.seq_provider: SequenceProvider = SequenceProvider(
@@ -86,7 +84,7 @@ class AcquisitionControl:
             rf_output_limit=self.config.tx.channel_max_amplitude[0],
             spcm_dwell_time=1 / (self.config.tx.sampling_rate * 1e6),
             rf_to_mvolt=self.config.tx.rf_to_mvolt,
-            system_limits=self.config.system,
+            system=self.config.system.get_opts(),
         )
         # Create transmit card instance
         self.tx_card: TxCard = TxCard(

--- a/src/console/utilities/sequences/tse/tse_3d.py
+++ b/src/console/utilities/sequences/tse/tse_3d.py
@@ -14,8 +14,9 @@ import ismrmrd
 import numpy as np
 import pypulseq as pp
 
-from console.interfaces.acquisition_parameter import Dimensions
-from console.utilities.sequences.system_settings import raster, system
+from console.interfaces.dimensions import Dimensions
+from console.utilities.sequences.system_settings import raster
+from console.utilities.sequences.system_settings import system as default_system
 
 
 class Trajectory(str, Enum):
@@ -53,7 +54,8 @@ def constructor(
     channel_ro: str = "y",
     channel_pe1: str = "z",
     channel_pe2: str = "x",
-    noise_scan: bool = False
+    noise_scan: bool = False,
+    system: pp.Opts = default_system,
 ) -> tuple[pp.Sequence, ismrmrd.xsd.ismrmrdHeader]:
     """Construct 3D turbo spin echo sequence.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -117,13 +117,6 @@ def test_sequence() -> pp.Sequence:
 
     rf_sinc = pp.make_sinc_pulse(flip_angle=np.pi / 2, delay=system.rf_dead_time, use="excitation", system=system)
     rf_rect = pp.make_block_pulse(flip_angle=np.pi, duration=200e-6, delay=system.rf_dead_time, system=system)
-    # rf_arbi = pp.make_arbitrary_rf(
-    #     signal=np.linspace(0, 0.0001, 100),
-    #     flip_angle=np.pi / 3,
-    #     dwell=system.rf_raster_time,
-    #     delay=system.rf_dead_time,
-    #     system=system,
-    # )
     grad_trap = pp.make_trapezoid(channel="x", area=system.max_grad*5e-3, system=system)
     grad_arbi = pp.make_arbitrary_grad(
         channel="y",
@@ -137,8 +130,8 @@ def test_sequence() -> pp.Sequence:
     label3 = pp.make_label(type="SET", label="ECO", value=3)
     label4 = pp.make_label(type="SET", label="REP", value=4)
     label5 = pp.make_label(type="SET", label="IMA", value=True)
-    adc1 = pp.make_adc(num_samples=200, dwell=1e-5, system=system)
-    adc2 = pp.make_adc(num_samples=500, dwell=1e-5, system=system)
+    adc1 = pp.make_adc(num_samples=200, dwell=1e-5, delay=system.adc_dead_time, system=system)
+    adc2 = pp.make_adc(num_samples=500, dwell=1e-5, delay=system.adc_dead_time, system=system)
 
     seq.add_block(rf_sinc)
     seq.add_block(grad_arbi, adc1)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -113,15 +113,33 @@ def test_sequence() -> pp.Sequence:
     system_limits: SystemLimits = load_system_limits(Path("examples/example_device_config.yaml"))
     seq = pp.Sequence(system=system_limits.get_opts())
     seq.set_definition("Name", "test_sequence")
-    seq.add_block(pp.make_sinc_pulse(flip_angle=np.pi / 2, system=system, delay=system.rf_dead_time))
+    seq.set_definition("label_float", 123.123)
+    seq.set_definition("label_int", 123)
+    seq.set_definition("label_str", "string")
+    rng = np.random.default_rng(seed=0)
+    rf_sinc = pp.make_sinc_pulse(flip_angle=np.pi / 2, delay=system.rf_dead_time, use="excitation", system=system)
+    rf_rect = pp.make_block_pulse(flip_angle=np.pi, duration=200e-6, delay=system.rf_dead_time, system=system)
+    rf_arbi = pp.make_arbitrary_rf(
+        signal=rng.random(size=100), flip_angle=np.pi / 3, dwell=1e-6, delay=system.rf_dead_time, system=system
+    )
+    grad_trap = pp.make_trapezoid(channel="x", area=rng.random(), system=system)
+    grad_arbi = pp.make_arbitrary_grad(channel="y", waveform=rng.random(50), system=system)
+    label1 = pp.make_label(type="SET", label="LIN", value=1)
+    label2 = pp.make_label(type="SET", label="PAR", value=2)
+    label3 = pp.make_label(type="SET", label="ECO", value=3)
+    label4 = pp.make_label(type="SET", label="REP", value=4)
+    label5 = pp.make_label(type="SET", label="IMA", value=True)
+    adc1 = pp.make_adc(num_samples=200, dwell=1e-5, system=system)
+    adc2 = pp.make_adc(num_samples=500, dwell=1e-5, system=system)
+    seq.add_block(rf_sinc)
     seq.add_block(pp.make_delay(10e-6))
-    seq.add_block(pp.make_trapezoid(channel="x", area=5e-3, system=system))
-    seq.add_block(pp.make_arbitrary_grad(
-        channel="y",
-        waveform=np.array([0, 200, 400, 400, 400, 600, 600, 400, 200, 0]),
-        system=system,
-    ))
-    seq.add_block(pp.make_adc(num_samples=200, dwell=1e-5))
+    seq.add_block(grad_arbi, adc1)
+    seq.add_block(rf_rect)
+    seq.add_block(grad_trap, label1, label2)
+    seq.add_block(pp.make_delay(4e-6))
+    seq.add_block(rf_arbi, label3)
+    seq.add_block(pp.make_delay(1e-6), label4)
+    seq.add_block(adc2, label5)
     return seq
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,7 +29,7 @@ def seq_provider() -> SequenceProvider:
         rf_50ohms=True,
         rf_to_mvolt=5e-3,
         spcm_dwell_time=5e-8,
-        system_limits=system_limits,
+        system=system_limits.get_opts(),
     )
 
 
@@ -110,7 +110,8 @@ def test_spectrum() -> Callable:
 @pytest.fixture()
 def test_sequence() -> pp.Sequence:
     """Construct a test sequence."""
-    seq = pp.Sequence(system=system)
+    system_limits: SystemLimits = load_system_limits(Path("examples/example_device_config.yaml"))
+    seq = pp.Sequence(system=system_limits.get_opts())
     seq.set_definition("Name", "test_sequence")
     seq.add_block(pp.make_sinc_pulse(flip_angle=np.pi / 2, system=system, delay=system.rf_dead_time))
     seq.add_block(pp.make_delay(10e-6))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,17 +9,16 @@ import pypulseq as pp
 import pytest
 
 from console.interfaces.acquisition_parameter import AcquisitionParameter, Dimensions
-from console.interfaces.device_configuration import SystemLimits
 from console.interfaces.rx_data import RxData
 from console.pulseq_interpreter.sequence_provider import SequenceProvider
 from console.utilities.load_configuration import load_system_limits
-from console.utilities.sequences.system_settings import system
+
+system = load_system_limits(Path("examples/example_device_config.yaml")).get_opts()
 
 
 @pytest.fixture()
 def seq_provider() -> SequenceProvider:
     """Construct default sequence provider as fixture for testing."""
-    system_limits: SystemLimits = load_system_limits(Path("examples/example_device_config.yaml"))
     return SequenceProvider(
         gradient_efficiency=(0.4, 0.4, 0.4),
         gpa_gain=(1.0, 1.0, 1.0),
@@ -29,7 +28,7 @@ def seq_provider() -> SequenceProvider:
         rf_50ohms=True,
         rf_to_mvolt=5e-3,
         spcm_dwell_time=5e-8,
-        system=system_limits.get_opts(),
+        system=system,
     )
 
 
@@ -110,20 +109,29 @@ def test_spectrum() -> Callable:
 @pytest.fixture()
 def test_sequence() -> pp.Sequence:
     """Construct a test sequence."""
-    system_limits: SystemLimits = load_system_limits(Path("examples/example_device_config.yaml"))
-    seq = pp.Sequence(system=system_limits.get_opts())
+    seq = pp.Sequence(system=system)
     seq.set_definition("Name", "test_sequence")
     seq.set_definition("label_float", 123.123)
     seq.set_definition("label_int", 123)
     seq.set_definition("label_str", "string")
-    rng = np.random.default_rng(seed=0)
+
     rf_sinc = pp.make_sinc_pulse(flip_angle=np.pi / 2, delay=system.rf_dead_time, use="excitation", system=system)
     rf_rect = pp.make_block_pulse(flip_angle=np.pi, duration=200e-6, delay=system.rf_dead_time, system=system)
-    rf_arbi = pp.make_arbitrary_rf(
-        signal=rng.random(size=100), flip_angle=np.pi / 3, dwell=1e-6, delay=system.rf_dead_time, system=system
+    # rf_arbi = pp.make_arbitrary_rf(
+    #     signal=np.linspace(0, 0.0001, 100),
+    #     flip_angle=np.pi / 3,
+    #     dwell=system.rf_raster_time,
+    #     delay=system.rf_dead_time,
+    #     system=system,
+    # )
+    grad_trap = pp.make_trapezoid(channel="x", area=system.max_grad*5e-3, system=system)
+    grad_arbi = pp.make_arbitrary_grad(
+        channel="y",
+        first=0.,
+        last=0.,
+        waveform=np.sin(np.linspace(0, 2*np.pi, 120))*25, # 50 mT max
+        system=system,
     )
-    grad_trap = pp.make_trapezoid(channel="x", area=rng.random(), system=system)
-    grad_arbi = pp.make_arbitrary_grad(channel="y", waveform=rng.random(50), system=system)
     label1 = pp.make_label(type="SET", label="LIN", value=1)
     label2 = pp.make_label(type="SET", label="PAR", value=2)
     label3 = pp.make_label(type="SET", label="ECO", value=3)
@@ -131,14 +139,12 @@ def test_sequence() -> pp.Sequence:
     label5 = pp.make_label(type="SET", label="IMA", value=True)
     adc1 = pp.make_adc(num_samples=200, dwell=1e-5, system=system)
     adc2 = pp.make_adc(num_samples=500, dwell=1e-5, system=system)
+
     seq.add_block(rf_sinc)
-    seq.add_block(pp.make_delay(10e-6))
     seq.add_block(grad_arbi, adc1)
     seq.add_block(rf_rect)
     seq.add_block(grad_trap, label1, label2)
-    seq.add_block(pp.make_delay(4e-6))
-    seq.add_block(rf_arbi, label3)
-    seq.add_block(pp.make_delay(1e-6), label4)
+    seq.add_block(pp.make_delay(4e-6), label3, label4)
     seq.add_block(adc2, label5)
     return seq
 

--- a/tests/sequence_tests/test_sequence_provider.py
+++ b/tests/sequence_tests/test_sequence_provider.py
@@ -10,6 +10,8 @@ from console.interfaces.acquisition_parameter import AcquisitionParameter
 from console.interfaces.rx_data import RxData
 from console.interfaces.unrolled_sequence import UnrolledSequence
 from console.pulseq_interpreter.sequence_provider import SequenceProvider
+from console.utilities.sequences import tse_3d
+from console.interfaces.dimensions import Dimensions
 
 
 def _compare_sequences(seq1: pp.Sequence, seq2: pp.Sequence) -> None:
@@ -62,6 +64,23 @@ def test_sequence_provider_to_pypulseq(seq_provider: SequenceProvider, test_sequ
         content_sliced = fh_sliced.read()
         content_ref = fh_ref.read()
     assert content_sliced == content_ref
+
+def test_sequence_provider_to_pypulseq_tse(seq_provider: SequenceProvider) -> None:
+    seq, _ = tse_3d.constructor(
+        n_enc=Dimensions(16, 32, 32),
+        # fov=Dimensions(x=140., y=140., z=140.),
+        etl=7,
+        echo_time=20.e-3,
+        trajectory=tse_3d.Trajectory.INOUT,
+        system=seq_provider.system,
+    )
+
+    seq_provider.from_pypulseq(seq)
+    sequence_out = seq_provider.to_pypulseq()
+
+    _compare_sequences(seq, seq_provider)
+    _compare_sequences(seq, sequence_out)
+
 
 def test_from_pypulseq(seq_provider):
     """from_pypulseq must raise AttributeError when passed an object without .system."""

--- a/tests/sequence_tests/test_sequence_provider.py
+++ b/tests/sequence_tests/test_sequence_provider.py
@@ -70,64 +70,6 @@ def test_dict_contains_basic_config(seq_provider: SequenceProvider):
     assert d["rf_to_mvolt"] == seq_provider.rf_to_mvolt
     assert d["output_limits"] == seq_provider.gradient_out_limits
 
-
-def test_from_pypulseq_system_limit_violation(seq_provider: SequenceProvider, test_sequence):
-    """from_pypulseq should raise ValueError when sequence system exceeds device limits."""
-    _max_grad = seq_provider.system_limits.max_grad
-    seq_provider.system_limits.max_grad = 0.0
-    with pytest.raises(ValueError):
-        seq_provider.from_pypulseq(test_sequence)
-    seq_provider.system_limits.max_grad = _max_grad
-
-    _max_slew = seq_provider.system_limits.max_slew
-    seq_provider.system_limits.max_grad = 0.0
-    with pytest.raises(ValueError):
-        seq_provider.from_pypulseq(test_sequence)
-    seq_provider.system_limits.max_slew = _max_slew
-
-    _grad_raster_time = seq_provider.system_limits.grad_raster_time
-    seq_provider.system_limits.grad_raster_time = 0.0
-    with pytest.raises(ValueError):
-        seq_provider.from_pypulseq(test_sequence)
-    seq_provider.system_limits.grad_raster_time = _grad_raster_time
-
-    _adc_raster_time = seq_provider.system_limits.adc_raster_time
-    seq_provider.system_limits.adc_raster_time = 0.0
-    with pytest.raises(ValueError):
-        seq_provider.from_pypulseq(test_sequence)
-    seq_provider.system_limits.adc_raster_time = _adc_raster_time
-
-    _rf_raster_time = seq_provider.system_limits.rf_raster_time
-    seq_provider.system_limits.rf_raster_time = 0.0
-    with pytest.raises(ValueError):
-        seq_provider.from_pypulseq(test_sequence)
-    seq_provider.system_limits.rf_raster_time = _rf_raster_time
-
-    _block_duration_raster = seq_provider.system_limits.block_duration_raster
-    seq_provider.system_limits.block_duration_raster = 0.0
-    with pytest.raises(ValueError):
-        seq_provider.from_pypulseq(test_sequence)
-    seq_provider.system_limits.block_duration_raster = _block_duration_raster
-
-    _adc_dead_time = seq_provider.system_limits.adc_dead_time
-    seq_provider.system_limits.adc_dead_time = -10.
-    with pytest.raises(ValueError):
-        seq_provider.from_pypulseq(test_sequence)
-    seq_provider.system_limits.adc_dead_time = _adc_dead_time
-
-    _rf_dead_time = seq_provider.system_limits.rf_dead_time
-    seq_provider.system_limits.rf_dead_time = -10.
-    with pytest.raises(ValueError):
-        seq_provider.from_pypulseq(test_sequence)
-    seq_provider.system_limits.rf_dead_time = _rf_dead_time
-
-    _rf_ringdown_time = seq_provider.system_limits.rf_ringdown_time
-    seq_provider.system_limits.rf_ringdown_time = -10.
-    with pytest.raises(ValueError):
-        seq_provider.from_pypulseq(test_sequence)
-    seq_provider.system_limits.rf_ringdown_time = _rf_ringdown_time
-
-
 def test_invalid_larmor_frequency(
     seq_provider: SequenceProvider,
     test_sequence,

--- a/tests/sequence_tests/test_sequence_provider.py
+++ b/tests/sequence_tests/test_sequence_provider.py
@@ -7,11 +7,11 @@ import pypulseq as pp
 import pytest
 
 from console.interfaces.acquisition_parameter import AcquisitionParameter
+from console.interfaces.dimensions import Dimensions
 from console.interfaces.rx_data import RxData
 from console.interfaces.unrolled_sequence import UnrolledSequence
 from console.pulseq_interpreter.sequence_provider import SequenceProvider
 from console.utilities.sequences import tse_3d
-from console.interfaces.dimensions import Dimensions
 
 
 def _compare_sequences(seq1: pp.Sequence, seq2: pp.Sequence) -> None:
@@ -66,6 +66,7 @@ def test_sequence_provider_to_pypulseq(seq_provider: SequenceProvider, test_sequ
     assert content_sliced == content_ref
 
 def test_sequence_provider_to_pypulseq_tse(seq_provider: SequenceProvider) -> None:
+    """Ensure TSE sequence remains unchanged when imported to sequence provider."""
     seq, _ = tse_3d.constructor(
         n_enc=Dimensions(16, 32, 32),
         # fov=Dimensions(x=140., y=140., z=140.),

--- a/tests/sequence_tests/test_sequence_provider.py
+++ b/tests/sequence_tests/test_sequence_provider.py
@@ -12,27 +12,43 @@ from console.interfaces.unrolled_sequence import UnrolledSequence
 from console.pulseq_interpreter.sequence_provider import SequenceProvider
 
 
+def _compare_sequences(seq1: pp.Sequence, seq2: pp.Sequence) -> None:
+    """Compare two pypulseq sequences and ensure equality."""
+    assert seq1 is not None
+    assert seq2 is not None
+    assert seq1.check_timing()[0] == seq2.check_timing()[0]
+    assert seq1.duration()[0] == seq2.duration()[0]
+    assert seq1.definitions == seq2.definitions
+    assert seq1.evaluate_labels() == seq2.evaluate_labels()
+    # Compare adc
+    t_adc_1, fp_adc_1 = seq1.adc_times()
+    t_adc_2, fp_adc_2 = seq2.adc_times()
+    np.testing.assert_array_equal(t_adc_1, t_adc_2)
+    np.testing.assert_array_equal(fp_adc_1, fp_adc_2)
+    # Compare k-space trajectory
+    k_traj_adc_1, k_traj_1, t_excitation_1, t_refocusing_1, _ = seq1.calculate_kspace()
+    k_traj_adc_2, k_traj_2, t_excitation_2, t_refocusing_2, _ = seq2.calculate_kspace()
+    np.testing.assert_array_equal(k_traj_adc_1, k_traj_adc_2)
+    np.testing.assert_array_equal(k_traj_1, k_traj_2)
+    np.testing.assert_array_equal(t_excitation_1, t_excitation_2)
+    np.testing.assert_array_equal(t_refocusing_1, t_refocusing_2)
+
 def test_unrolling(seq_provider: SequenceProvider, test_sequence, acquisition_parameter):
     """Test unrolled sequence plot."""
     assert test_sequence.check_timing()[0]
-
     seq_provider.from_pypulseq(test_sequence)
     unrolled_seq: UnrolledSequence = seq_provider.unroll_sequence(acquisition_parameter)
     assert unrolled_seq.duration == test_sequence.duration()[0]
 
-
-def test_sequence_provider_to_pypulseq(seq_provider: SequenceProvider, test_sequence):
+def test_sequence_provider_to_pypulseq(seq_provider: SequenceProvider, test_sequence: pp.Sequence) -> None:
     """Test if sequence can be generated from sequence provider."""
+    # Ensure test sequence is valid
+    assert test_sequence.check_timing()[0]
     seq_provider.from_pypulseq(test_sequence)
     sequence_out = seq_provider.to_pypulseq()
 
-    assert sequence_out is not None
-
-    for key, value in vars(test_sequence).items():
-        assert hasattr(sequence_out, key)
-        assert getattr(sequence_out, key) == value
-
-    assert sequence_out.duration()[0] == test_sequence.duration()[0]
+    # Test sequence loaded to sequence provider
+    _compare_sequences(test_sequence, sequence_out)
 
     # Save sequences and compare file content
     tmp_dir = Path(tempfile.mkdtemp())
@@ -41,18 +57,16 @@ def test_sequence_provider_to_pypulseq(seq_provider: SequenceProvider, test_sequ
 
     sequence_out.write(sliced_file)
     test_sequence.write(reference_file)
-
-    with open(sliced_file, "r") as fh_sliced, open(reference_file, "r") as fh_ref:
+    # Compare file content
+    with Path.open(sliced_file, "r") as fh_sliced, Path.open(reference_file, "r") as fh_ref:
         content_sliced = fh_sliced.read()
         content_ref = fh_ref.read()
     assert content_sliced == content_ref
-
 
 def test_from_pypulseq(seq_provider):
     """from_pypulseq must raise AttributeError when passed an object without .system."""
     with pytest.raises(AttributeError):
         seq_provider.from_pypulseq(object())
-
 
 def test_dict_contains_basic_config(seq_provider: SequenceProvider):
     """Ensure dict() exposes the main configuration for logging/debugging."""
@@ -120,7 +134,6 @@ def test_calculate_arbitrary_gradient_block(seq_provider: SequenceProvider):
             block=block, fov_scaling=1., offset=seq_provider.gradient_out_limits[1], output_channel=1,
         )
 
-
 def test_calculate_trapezoid_gradient_block(seq_provider: SequenceProvider):
     """Cover _calculate_gradient for type 'trap'."""
     block = pp.make_trapezoid(
@@ -145,7 +158,6 @@ def test_calculate_trapezoid_gradient_block(seq_provider: SequenceProvider):
         _ = seq_provider._calculate_gradient(
             block=block, fov_scaling=1., offset=seq_provider.gradient_out_limits[1], output_channel=1,
         )
-
 
 def test_calculate_rf_block(seq_provider: SequenceProvider):
     """Cover _calculate_rf for valid and invalid RF blocks."""


### PR DESCRIPTION
Before calculating a sequence, it must be loaded to the sequence interpreter. This can be achieved either by using the `from_pypulseq` method or the `read` method of the interpreter, which is inherited from the pypulseq `Sequence`.
When using `from_pypulseq`, so far the system limits were checked and compared to the system specified in the device configuration, before all the attributes of `Sequence` were overwritten in `SequenceProvider`. Thereby also the sequence system was overwritten.

With this PR the system defined in the device configuration is considered to be fixed. A sequence, no matter if it is loaded from file or from an existing pypulseq `Sequence` should not touch the system configuration.