### PR TITLE
Fixed sequence definition overwrite in `from_pypulseq` method.

### DIFF
--- a/src/console/pulseq_interpreter/sequence_provider.py
+++ b/src/console/pulseq_interpreter/sequence_provider.py
@@ -147,8 +147,9 @@ class SequenceProvider(Sequence):
         for block_index, _ in seq.block_events.items():
             block = seq.get_block(block_index)
             self.add_block(block)
-        # Set definitions
-        self.definitions = seq.definitions
+        # Set definitions without overwriting existing ones
+        for key, value in seq.definitions.items():
+            self.definitions.setdefault(key, value)
 
     def to_pypulseq(self) -> Sequence | None:
         """Create a pypulseq sequence from sequence provider."""

--- a/tests/sequence_tests/test_sequence_provider.py
+++ b/tests/sequence_tests/test_sequence_provider.py
@@ -69,22 +69,26 @@ def test_sequence_provider_to_pypulseq(seq_provider: SequenceProvider, test_sequ
 
 def test_sequence_provider_write_fid_sequence(seq_provider: SequenceProvider, tmp_path: Path) -> None:
     """Test if sequence can be generated from sequence provider."""
-    seq = fid.constructor(system=seq_provider.system)
+    seq = fid.constructor()
     seq_provider.from_pypulseq(seq)
 
-    # Save sequences and compare file content
-    provider_file = tmp_path / "seq_provider.seq"
+    # Save and reload reference sequence
     reference_file = tmp_path / "reference.seq"
-
     seq.write(reference_file)
+    seq_1 = pp.Sequence()
+    seq_1.read(reference_file)
+
+    # Save and reload sequence through sequence provider
+    provider_file = tmp_path / "seq_provider.seq"
     seq_provider.write(provider_file)
+    seq_2 = pp.Sequence()
+    seq_2.read(provider_file)
 
-    # Compare file content
-    with Path.open(provider_file, "r") as fh_provider, Path.open(reference_file, "r") as fh_reference:
-        content_sliced = fh_provider.read()
-        content_ref = fh_reference.read()
-
-    assert content_sliced == content_ref
+    # Compare block durations
+    for k in range(len(seq.block_events)):
+        block_1 = seq_1.get_block(k+1)
+        block_2 = seq_2.get_block(k+1)
+        assert block_1.block_duration == block_2.block_duration
 
 def test_sequence_provider_to_pypulseq_tse(seq_provider: SequenceProvider) -> None:
     """Ensure TSE sequence remains unchanged when imported to sequence provider."""

--- a/tests/sequence_tests/test_sequence_provider.py
+++ b/tests/sequence_tests/test_sequence_provider.py
@@ -12,6 +12,7 @@ from console.interfaces.rx_data import RxData
 from console.interfaces.unrolled_sequence import UnrolledSequence
 from console.pulseq_interpreter.sequence_provider import SequenceProvider
 from console.utilities.sequences import tse_3d
+from console.utilities.sequences.spectrometry import fid
 
 
 def _compare_sequences(seq1: pp.Sequence, seq2: pp.Sequence) -> None:
@@ -48,6 +49,7 @@ def test_sequence_provider_to_pypulseq(seq_provider: SequenceProvider, test_sequ
     assert test_sequence.check_timing()[0]
     seq_provider.from_pypulseq(test_sequence)
     sequence_out = seq_provider.to_pypulseq()
+    assert isinstance(sequence_out, pp.Sequence)
 
     # Test sequence loaded to sequence provider
     _compare_sequences(test_sequence, sequence_out)
@@ -63,6 +65,25 @@ def test_sequence_provider_to_pypulseq(seq_provider: SequenceProvider, test_sequ
     with Path.open(sliced_file, "r") as fh_sliced, Path.open(reference_file, "r") as fh_ref:
         content_sliced = fh_sliced.read()
         content_ref = fh_ref.read()
+    assert content_sliced == content_ref
+
+def test_sequence_provider_write_fid_sequence(seq_provider: SequenceProvider, tmp_path: Path) -> None:
+    """Test if sequence can be generated from sequence provider."""
+    seq = fid.constructor(system=seq_provider.system)
+    seq_provider.from_pypulseq(seq)
+
+    # Save sequences and compare file content
+    provider_file = tmp_path / "seq_provider.seq"
+    reference_file = tmp_path / "reference.seq"
+
+    seq.write(reference_file)
+    seq_provider.write(provider_file)
+
+    # Compare file content
+    with Path.open(provider_file, "r") as fh_provider, Path.open(reference_file, "r") as fh_reference:
+        content_sliced = fh_provider.read()
+        content_ref = fh_reference.read()
+
     assert content_sliced == content_ref
 
 def test_sequence_provider_to_pypulseq_tse(seq_provider: SequenceProvider) -> None:


### PR DESCRIPTION
Instead of overwriting the definitions in `from_pypulseq` method of the `SequenceProvider`, existing definitions remain unchanged (e.g. BlockDurationRaster) and only new definitions are added. Closes #162 