### PR TITLE
Unify usage "default system"

### DIFF
--- a/examples/example_device_config.yaml
+++ b/examples/example_device_config.yaml
@@ -48,18 +48,18 @@ SystemLimits:
   # Maximum gradient amplitude in Hz/m (PyPulseq system stores this unit)
   max_grad: 1703040.0 # equals 40 mT/m
   # Maximum slew rate in Hz/m/s (PyPulseq system stores this unit)
-  max_slew: 4257600000.0 # equals 100 T/m/s
+  max_slew: 2128800000.0 # equals 100 T/m/s
   # Dead time at the beginning of RF event in s, covered by rf_delay
   rf_dead_time: 20.e-6
   # Time delay at the end of an RF event in s
-  rf_ringdown_time: 20.e-6
+  rf_ringdown_time: 30.e-6
   # Time delay at the beginning of an ADC event in s
   adc_dead_time: 0.
   # Raster time for block durations
-  block_duration_raster: 5.e-8
+  block_duration_raster: 1.e-6
   # Raster time for RF pulses.
-  rf_raster_time: 5.e-8
+  rf_raster_time: 1.e-6
   # Raster time for gradient waveforms.
-  grad_raster_time: 5.e-8
+  grad_raster_time: 1.e-6
   # Raster time for ADC readout.
-  adc_raster_time: 5.e-8
+  adc_raster_time: 1.e-6

--- a/src/console/spcm_control/spcm/tools.py
+++ b/src/console/spcm_control/spcm/tools.py
@@ -55,7 +55,6 @@ def translate_error(error: int) -> str | None:
     if error in error_reg.keys():
         if error_reg[error] is not ERR_OK:
             return f"ERROR: {error_reg[error]}"
-        return None
     return "Unknown error"
 
 

--- a/src/console/utilities/sequences/calibration/fid_tx_adjust.py
+++ b/src/console/utilities/sequences/calibration/fid_tx_adjust.py
@@ -24,23 +24,23 @@ def constructor(
 
     Parameters
     ----------
-    n_steps
+    n_steps, optional
         Number of flip angles
-    flip_angle_range
+    flip_angle_range, optional
         Range of flip angles in rad
-    repetition_time
+    repetition_time, optional
         Repetition time in s
-    rf_duration
+    rf_duration, optional
         RF pulse duration in s
-    use_sinc
+    use_sinc, optional
         RF pulse type, if true sinc pulse is used, rect otherwise
-    num_adc_samples
+    num_adc_samples, optional
         Number of ADC samples
-    acq_bandwidth
+    acq_bandwidth, optional
         Acquisition bandwidth in Hz
-    ring_down_time
+    ring_down_time, optional
         RF ring down time in s
-    system
+    system, optional
         Sequence system to be used for sequence construction
 
     Returns

--- a/src/console/utilities/sequences/calibration/fid_tx_adjust.py
+++ b/src/console/utilities/sequences/calibration/fid_tx_adjust.py
@@ -41,7 +41,7 @@ def constructor(
     ring_down_time
         RF ring down time in s
     system
-        Sequence system to be used for sequence construction      
+        Sequence system to be used for sequence construction
 
     Returns
     -------

--- a/src/console/utilities/sequences/calibration/fid_tx_adjust.py
+++ b/src/console/utilities/sequences/calibration/fid_tx_adjust.py
@@ -5,7 +5,8 @@ from math import pi
 import numpy as np
 import pypulseq as pp
 
-from console.utilities.sequences.system_settings import raster, system
+from console.utilities.sequences.system_settings import raster
+from console.utilities.sequences.system_settings import system as default_system
 
 
 def constructor(
@@ -16,7 +17,8 @@ def constructor(
     use_sinc: bool = False,
     num_adc_samples: int = 256,
     acq_bandwidth: float | int = 20e3,
-    ring_down_time: float = 2e-3
+    ring_down_time: float = 2e-3,
+    system: pp.Opts = default_system,
 ) -> tuple[pp.Sequence, np.ndarray]:
     """Construct transmit adjust sequence.
 
@@ -38,6 +40,8 @@ def constructor(
         Acquisition bandwidth in Hz
     ring_down_time
         RF ring down time in s
+    system
+        Sequence system to be used for sequence construction      
 
     Returns
     -------

--- a/src/console/utilities/sequences/calibration/se_tx_adjust.py
+++ b/src/console/utilities/sequences/calibration/se_tx_adjust.py
@@ -16,7 +16,7 @@ def constructor(
     rf_duration: float = 400e-6,
     acq_bandwidth: float | int = 50e3,
     use_sinc: bool = False,
-    system: pp.Opts = default_system,    
+    system: pp.Opts = default_system,
 ) -> tuple[pp.Sequence, np.ndarray]:
     """Construct transmit adjust sequence.
 
@@ -38,7 +38,7 @@ def constructor(
         Use sinc pulse if True, block pulse otherwise
     system
         Sequence system to be used for sequence construction
-        
+
     Returns
     -------
         Pypulseq ``Sequence`` instance and flip angles in rad

--- a/src/console/utilities/sequences/calibration/se_tx_adjust.py
+++ b/src/console/utilities/sequences/calibration/se_tx_adjust.py
@@ -4,7 +4,8 @@ from math import pi
 import numpy as np
 import pypulseq as pp
 
-from console.utilities.sequences.system_settings import raster, system
+from console.utilities.sequences.system_settings import raster
+from console.utilities.sequences.system_settings import system as default_system
 
 
 def constructor(
@@ -14,7 +15,8 @@ def constructor(
     echo_time: float = 20e-3,
     rf_duration: float = 400e-6,
     acq_bandwidth: float | int = 50e3,
-    use_sinc: bool = False
+    use_sinc: bool = False,
+    system: pp.Opts = default_system,    
 ) -> tuple[pp.Sequence, np.ndarray]:
     """Construct transmit adjust sequence.
 
@@ -34,7 +36,9 @@ def constructor(
         Acquisition bandwidth in Hz
     use_sinc
         Use sinc pulse if True, block pulse otherwise
-
+    system
+        Sequence system to be used for sequence construction
+        
     Returns
     -------
         Pypulseq ``Sequence`` instance and flip angles in rad

--- a/src/console/utilities/sequences/calibration/se_tx_adjust.py
+++ b/src/console/utilities/sequences/calibration/se_tx_adjust.py
@@ -22,21 +22,21 @@ def constructor(
 
     Parameters
     ----------
-    n_steps
+    n_steps, optional
         Number of flip angles
-    flip_angle_range
+    flip_angle_range, optional
         Range of flip angles in rad
-    repetition_time
+    repetition_time, optional
         Repetition time in s
-    echo_time
+    echo_time, optional
         Echo time in s
-    rf_duration
+    rf_duration, optional
         RF duration in s
-    acq_bandwidth
+    acq_bandwidth, optional
         Acquisition bandwidth in Hz
-    use_sinc
+    use_sinc, optional
         Use sinc pulse if True, block pulse otherwise
-    system
+    system, optional
         Sequence system to be used for sequence construction
 
     Returns

--- a/src/console/utilities/sequences/spectrometry/fid.py
+++ b/src/console/utilities/sequences/spectrometry/fid.py
@@ -8,6 +8,7 @@ from console.utilities.sequences.system_settings import system as default_system
 
 def constructor(
     rf_duration: float = 200e-6,
+    dead_time: float = 0.,
     num_samples: int = 256,
     acq_bandwidth: float | int = 20e3,
     use_sinc: bool = False,
@@ -21,6 +22,8 @@ def constructor(
     ----------
     rf_duration, optional
         RF duration in s
+    dead_time, optional
+        Additional time delay between RF pulse and ADC readout
     num_samples, optional
         Number of ADC sample points
     acq_bandwidth, optional
@@ -67,8 +70,13 @@ def constructor(
         phase_offset=0,
         system=system,
     )
+    # Define delay to account for RF ringing
+    ring_down_delay = pp.make_delay(
+        round((dead_time) / 1e-6) * 1e-6,
+    )
 
     seq.add_block(rf_90)
+    seq.add_block(ring_down_delay)
     seq.add_block(adc)
 
     return seq

--- a/src/console/utilities/sequences/spectrometry/fid.py
+++ b/src/console/utilities/sequences/spectrometry/fid.py
@@ -19,19 +19,19 @@ def constructor(
 
     Parameters
     ----------
-    rf_duration
+    rf_duration, optional
         RF duration in s
-    num_samples
+    num_samples, optional
         Number of ADC sample points
-    acq_bandwidth
+    acq_bandwidth, optional
         Acquisition bandwidth in Hz
-    use_sinc
+    use_sinc, optional
         If set, sinc RF pulse is used, otherwise block pulse
-    time_bw_product
+    time_bw_product, optional
         Time bandwidth product
-    flip_angle
+    flip_angle, optional
         Flip angle of RF pulse
-    system
+    system, optional
         Sequence system to be used for sequence construction
 
     Returns

--- a/src/console/utilities/sequences/spectrometry/fid.py
+++ b/src/console/utilities/sequences/spectrometry/fid.py
@@ -19,20 +19,20 @@ def constructor(
 
     Parameters
     ----------
-    rf_duration, optional
-        RF duration in s, by default 200e-6
-    num_samples, optional
-        Number of ADC sample points, by default 256
-    acq_bandwidth, optional
-        Acquisition bandwidth in Hz, by default 20e3
-    use_sinc, optional
-        If set, sinc RF pulse is used, otherwise block pulse, by default False
-    time_bw_product, optional
-        Time bandwidth product, by default 4
-    flip_angle, optional
-        Flip angle of RF pulse, by default pi/2
-    system, optional
-        Sequence system to be used for sequence construction, by default default_system
+    rf_duration
+        RF duration in s
+    num_samples
+        Number of ADC sample points
+    acq_bandwidth
+        Acquisition bandwidth in Hz
+    use_sinc
+        If set, sinc RF pulse is used, otherwise block pulse
+    time_bw_product
+        Time bandwidth product
+    flip_angle
+        Flip angle of RF pulse
+    system
+        Sequence system to be used for sequence construction
 
     Returns
     -------

--- a/src/console/utilities/sequences/spectrometry/se_projection.py
+++ b/src/console/utilities/sequences/spectrometry/se_projection.py
@@ -24,23 +24,23 @@ def constructor(
 
     Parameters
     ----------
-    fov
+    fov, optional
         Field of view in m
-    readout_bandwidth
+    readout_bandwidth, optional
         Readout bandwidth in Hz
-    echo_time
+    echo_time, optional
         Time between center of 90 degree pulse and center of ADC in s
-    gradient_correction
+    gradient_correction, optional
         Additional delay to account for gradient system delays in s
-    num_samples
+    num_samples, optional
         Number of data points to acquire
-    rf_duration
+    rf_duration, optional
         Duration of the RF pulses in s
-    channel
+    channel, optional
         Gradient channel to use for projection
-    use_sinc
+    use_sinc, optional
         RF pulse type, if true: sinc pulse is used, rect otherwise
-    system
+    system, optional
         Sequence system to be used for sequence construction
 
     Returns

--- a/src/console/utilities/sequences/spectrometry/se_projection.py
+++ b/src/console/utilities/sequences/spectrometry/se_projection.py
@@ -41,7 +41,7 @@ def constructor(
     use_sinc
         RF pulse type, if true: sinc pulse is used, rect otherwise
     system
-        Sequence system to be used for sequence construction    
+        Sequence system to be used for sequence construction
 
     Returns
     -------

--- a/src/console/utilities/sequences/spectrometry/se_projection.py
+++ b/src/console/utilities/sequences/spectrometry/se_projection.py
@@ -5,7 +5,8 @@ from math import pi
 
 import pypulseq as pp
 
-from console.utilities.sequences.system_settings import raster, system
+from console.utilities.sequences.system_settings import raster
+from console.utilities.sequences.system_settings import system as default_system
 
 
 def constructor(
@@ -17,6 +18,7 @@ def constructor(
     rf_duration: float = 400e-6,
     channel: str = "x",
     use_sinc: bool = False,
+    system: pp.Opts = default_system,
 ) -> pp.Sequence:
     """Construct spin echo spectrum sequence with projection gradient (1D).
 
@@ -38,6 +40,8 @@ def constructor(
         Gradient channel to use for projection
     use_sinc
         RF pulse type, if true: sinc pulse is used, rect otherwise
+    system
+        Sequence system to be used for sequence construction    
 
     Returns
     -------

--- a/src/console/utilities/sequences/spectrometry/se_spectrum.py
+++ b/src/console/utilities/sequences/spectrometry/se_spectrum.py
@@ -21,21 +21,21 @@ def constructor(
 
     Parameters
     ----------
-    echo_time
+    echo_time, optional
         Time between center of 90 degree pulse and center of ADC in s
-    rf_duration
+    rf_duration, optional
         Duration of the RF pulses in s
-    num_samples
+    num_samples, optional
         Number of data points to acquire
-    acq_bandwidth
+    acq_bandwidth, optional
         Bandwidth of the acquisition in Hz
-    use_sinc
+    use_sinc, optional
         RF pulse type, if true sinc pulse is used, rect otherwise
-    time_bw_product
+    time_bw_product, optional
         Time-bandwidth product for the sinc pulse
-    use_fid
+    use_fid, optional
         If true, only acquire FID part of the spin-echo
-    system
+    system, optional
         Sequence system to be used for sequence construction
 
     Returns

--- a/src/console/utilities/sequences/spectrometry/se_spectrum.py
+++ b/src/console/utilities/sequences/spectrometry/se_spectrum.py
@@ -36,7 +36,7 @@ def constructor(
     use_fid
         If true, only acquire FID part of the spin-echo
     system
-        Sequence system to be used for sequence construction       
+        Sequence system to be used for sequence construction
 
     Returns
     -------

--- a/src/console/utilities/sequences/spectrometry/se_spectrum.py
+++ b/src/console/utilities/sequences/spectrometry/se_spectrum.py
@@ -15,7 +15,7 @@ def constructor(
     use_sinc: bool = False,
     time_bw_product: float = 4,
     use_fid: bool = True,
-    system: pp.Opts | None = None,
+    system: pp.Opts = default_system,
 ) -> pp.Sequence:
     """Construct spin echo spectrum sequence.
 
@@ -35,6 +35,8 @@ def constructor(
         Time-bandwidth product for the sinc pulse
     use_fid
         If true, only acquire FID part of the spin-echo
+    system
+        Sequence system to be used for sequence construction       
 
     Returns
     -------
@@ -45,7 +47,7 @@ def constructor(
     ValueError
         Sequence timing check failed
     """
-    seq = pp.Sequence(system=system) if system is not None else pp.Sequence(system=default_system)
+    seq = pp.Sequence(system=system)
 
     if use_fid:
         seq.set_definition("Name", "se_decay_spectrum")
@@ -55,60 +57,60 @@ def constructor(
     # Define RF pulses for excitation and refocusing
     if use_sinc:
         rf_90 = pp.make_sinc_pulse(
-            system=seq.system,
+            system=system,
             flip_angle=pi / 2,
             phase_offset=0,
             duration=rf_duration,
             time_bw_product=time_bw_product,
-            delay=seq.system.rf_dead_time,
+            delay=system.rf_dead_time,
         )
         rf_180 = pp.make_sinc_pulse(
-            system=seq.system,
+            system=system,
             flip_angle=pi,
             phase_offset=pi / 2,
             duration=rf_duration,
             time_bw_product=time_bw_product,
-            delay=seq.system.rf_dead_time,
+            delay=system.rf_dead_time,
         )
     else:
         rf_90 = pp.make_block_pulse(
-            system=seq.system,
+            system=system,
             flip_angle=pi / 2,
             phase_offset=0,
             duration=rf_duration,
-            delay=seq.system.rf_dead_time,
+            delay=system.rf_dead_time,
         )
         rf_180 = pp.make_block_pulse(
-            system=seq.system,
+            system=system,
             flip_angle=pi,
             phase_offset=pi / 2,
             duration=rf_duration,
-            delay=seq.system.rf_dead_time,
+            delay=system.rf_dead_time,
         )
     # Define ADC duration
-    adc_duration = raster(val=num_samples / acq_bandwidth, precision=seq.system.adc_raster_time)
+    adc_duration = raster(val=num_samples / acq_bandwidth, precision=system.adc_raster_time)
 
     # Define ADC event
     adc = pp.make_adc(
         num_samples=num_samples,
         duration=adc_duration,
-        system=seq.system,
+        system=system,
     )
 
     # Calculate delays to achieve desired echo time
     te_delay_1 = raster(
         echo_time / 2 - rf_duration - rf_90.ringdown_time - rf_180.delay,
-        seq.system.grad_raster_time,
+        system.grad_raster_time,
     )
     if use_fid:
         te_delay_2 = raster(
             echo_time / 2 - rf_duration / 2 - rf_180.ringdown_time - adc.dead_time,
-            seq.system.grad_raster_time,
+            system.grad_raster_time,
         )
     else:
         te_delay_2 = raster(
             echo_time / 2 - rf_duration / 2 - adc_duration / 2 - rf_180.ringdown_time - adc.dead_time,
-            seq.system.grad_raster_time,
+            system.grad_raster_time,
         )
 
     seq.add_block(rf_90)

--- a/src/console/utilities/sequences/spectrometry/t2_relaxation.py
+++ b/src/console/utilities/sequences/spectrometry/t2_relaxation.py
@@ -4,7 +4,8 @@ from math import pi
 import numpy as np
 import pypulseq as pp
 
-from console.utilities.sequences.system_settings import raster, system
+from console.utilities.sequences.system_settings import raster
+from console.utilities.sequences.system_settings import system as default_system
 
 
 def constructor(
@@ -13,7 +14,8 @@ def constructor(
     repetition_time: float = 600e-3,
     rf_duration: float = 400e-6,
     num_samples: int = 64,
-    acq_bandwidth: float | int = 20e3
+    acq_bandwidth: float | int = 20e3,
+    system: pp.Opts = default_system,
     ) -> tuple[pp.Sequence, np.ndarray]:
     """Construct spin echo T2 relaxation sequence.
 
@@ -31,6 +33,8 @@ def constructor(
         Number of data points to acquire
     acq_bandwidth
         Bandwidth of the acquisition in Hz
+    system
+        Sequence system to be used for sequence construction        
 
     Returns
     -------

--- a/src/console/utilities/sequences/spectrometry/t2_relaxation.py
+++ b/src/console/utilities/sequences/spectrometry/t2_relaxation.py
@@ -21,19 +21,19 @@ def constructor(
 
     Parameters
     ----------
-    echo_time_range
+    echo_time_range, optional
         Range of echo times in s
-    num_steps
+    num_steps, optional
         Number of echo times to sample
-    repetition_time
+    repetition_time, optional
         Time between two subsequent 90 degree pulses in s
-    rf_duration
+    rf_duration, optional
         Duration of the RF pulses in s
-    num_samples
+    num_samples, optional
         Number of data points to acquire
-    acq_bandwidth
+    acq_bandwidth, optional
         Bandwidth of the acquisition in Hz
-    system
+    system, optional
         Sequence system to be used for sequence construction
 
     Returns

--- a/src/console/utilities/sequences/spectrometry/t2_relaxation.py
+++ b/src/console/utilities/sequences/spectrometry/t2_relaxation.py
@@ -34,7 +34,7 @@ def constructor(
     acq_bandwidth
         Bandwidth of the acquisition in Hz
     system
-        Sequence system to be used for sequence construction        
+        Sequence system to be used for sequence construction
 
     Returns
     -------

--- a/src/console/utilities/sequences/system_settings.py
+++ b/src/console/utilities/sequences/system_settings.py
@@ -10,10 +10,10 @@ system = Opts(
     block_duration_raster=1e-6,
     adc_raster_time=1e-6,
 
-    # Time delay at the beginning of an RF event, SETS RF DELAY!
-    rf_dead_time=100e-6,
-    # time delay at the end of RF event
-    rf_ringdown_time=20e-6,
+    # Time delay at the beginning of an RF event, covered by rf_delay.
+    rf_dead_time=20e-6,
+    # Time delay at the end of RF event
+    rf_ringdown_time=30e-6,
     # Time delay at the beginning of ADC event
     adc_dead_time=0.,
 

--- a/src/console/utilities/sequences/tse/tse_3d.py
+++ b/src/console/utilities/sequences/tse/tse_3d.py
@@ -61,48 +61,48 @@ def constructor(
 
     Parameters
     ----------
-    echo_time
+    echo_time, optional
         Time constant between center of 90 degree pulse and center of ADC
-    repetition_time
+    repetition_time, optional
         Time constant between two subsequent 90 degree pulses (echo trains)
-    etl
+    etl, optional
         Echo train length
-    dummies
+    dummies, optional
         Number of dummy shots to acquire
-    rf_duration
+    rf_duration, optional
         Duration of the RF pulses (90 and 180 degree)
-    ramp_duration
+    ramp_duration, optional
         Duration of the gradient ramps
-    gradient_correction
+    gradient_correction, optional
         Time constant to center ADC event
-    adc_correction
+    adc_correction, optional
         Time constant which is added at the end of the ADC and readout gradient.
         This value is not taken into account for the prephaser calculation.
-    ro_bandwidth
+    ro_bandwidth, optional
         Readout bandwidth in Hz
-    fov
+    fov, optional
         Field of view per dimension
-    n_enc
+    n_enc, optional
         Number of encoding steps per dimension
         If an encoding dimension is set to 1, the TSE sequence becomes a 2D sequence.
-    trajectory
+    trajectory, optional
         The k-space trajectory, options are in-out, out-in and linear
-    excitation_angle, excitation_phase
+    excitation_angle, excitation_phase, optional
         set the flip angle and phase of the excitation pulse in radians
-    refocussing_angle, refocussing_phase
+    refocussing_angle, refocussing_phase, optional
         Set the flip angle and phase of the refocussing pulse in radians
         TODO: allow this to be a list/array to vary flip angle along echo train.
-    inversion_pulse
+    inversion_pulse, optional
         If true, an inversion pulse is added at the beginning of each TR, with inversion time defined by inversion_time
-    inversion_time
+    inversion_time, optional
         Time between inversion pulse and excitation pulse in s, only used if inversion_pulse is true
-    inversion_angle
+    inversion_angle, optional
         Flip angle of the inversion pulse in radians, only used if inversion_pulse is true
-    channel_ro, channel_pe1, channel_pe2
+    channel_ro, channel_pe1, channel_pe2, optional
         set the readout, phase1 and phase2 encoding directions
-    noise_scan
+    noise_scan, optional
         If true, a noise scan is acquired after each echo train, with the same duration as the echo train
-    system
+    system, optional
         Sequence system to be used for sequence construction
 
     Returns

--- a/src/console/utilities/sequences/tse/tse_3d.py
+++ b/src/console/utilities/sequences/tse/tse_3d.py
@@ -61,44 +61,55 @@ def constructor(
 
     Parameters
     ----------
-    echo_time, optional
-        Time constant between center of 90 degree pulse and center of ADC, by default 15e-3
-    repetition_time, optional
-        Time constant between two subsequent 90 degree pulses (echo trains), by default 600e-3
-    etl, optional
-        Echo train length, by default 7
-    dummies, optional
-        Number of dummy shots to acquire, default is 0
-    rf_duration, optional
-        Duration of the RF pulses (90 and 180 degree), by default 400e-6
-    gradient_correction, optional
-        Time constant to center ADC event, by default 510e-6
-    adc_correction, optional
+    echo_time
+        Time constant between center of 90 degree pulse and center of ADC
+    repetition_time
+        Time constant between two subsequent 90 degree pulses (echo trains)
+    etl
+        Echo train length
+    dummies
+        Number of dummy shots to acquire
+    rf_duration
+        Duration of the RF pulses (90 and 180 degree)
+    ramp_duration        
+        Duration of the gradient ramps
+    gradient_correction
+        Time constant to center ADC event
+    adc_correction
         Time constant which is added at the end of the ADC and readout gradient.
         This value is not taken into account for the prephaser calculation.
-    ro_bandwidth, optional
-        Readout bandwidth in Hz, by default 20e3
-    fov, optional
-        Field of view per dimension, by default default_fov
-    n_enc, optional
-        Number of encoding steps per dimension, by default default_encoding = Dimensions(x=70, y=70, z=49).
+    ro_bandwidth
+        Readout bandwidth in Hz
+    fov
+        Field of view per dimension
+    n_enc
+        Number of encoding steps per dimension
         If an encoding dimension is set to 1, the TSE sequence becomes a 2D sequence.
-    trajectory, optional
-        The k-space trajectory, by default set to in-out, other currently implemented options are out in and linear
-    excitation_angle, excitation_phase, optional
-        set the flip angle and phase of the excitation pulse in radians, defaults to 90 degree flip angle, 0 phase
-    refocussing_angle, refocussing_phase, optional
-        Set the flip angle and phase of the refocussing pulse in radians,
-        defaults to 180 degree flip angle, 90 degree phase
+    trajectory
+        The k-space trajectory, options are in-out, out-in and linear
+    excitation_angle, excitation_phase
+        set the flip angle and phase of the excitation pulse in radians
+    refocussing_angle, refocussing_phase
+        Set the flip angle and phase of the refocussing pulse in radians
         TODO: allow this to be a list/array to vary flip angle along echo train.
-    channel_ro, channel_pe1, channel_pe2, optional
-        set the readout, phase1 and phase2 encoding directions, default to y, z and x.
+    inversion_pulse
+        If true, an inversion pulse is added at the beginning of each TR, with inversion time defined by inversion_time
+    inversion_time
+        Time between inversion pulse and excitation pulse in s, only used if inversion_pulse is true
+    inversion_angle
+        Flip angle of the inversion pulse in radians, only used if inversion_pulse is true
+    channel_ro, channel_pe1, channel_pe2
+        set the readout, phase1 and phase2 encoding directions
+    noise_scan
+        If true, a noise scan is acquired after each echo train, with the same duration as the echo train
+    system
+        Sequence system to be used for sequence construction       
 
     Returns
     -------
         Pulseq sequence and a list which describes the trajectory
     """
-    seq = pp.Sequence(system)
+    seq = pp.Sequence(system=system)
     # Get the dimension and type of the sequence and set the name accordingly
     n_dim = int(n_enc.x > 1) + int(n_enc.y > 1) + int(n_enc.z > 1)
     seq_type = "tse" if etl > 1 else "se"

--- a/src/console/utilities/sequences/tse/tse_3d.py
+++ b/src/console/utilities/sequences/tse/tse_3d.py
@@ -71,7 +71,7 @@ def constructor(
         Number of dummy shots to acquire
     rf_duration
         Duration of the RF pulses (90 and 180 degree)
-    ramp_duration        
+    ramp_duration
         Duration of the gradient ramps
     gradient_correction
         Time constant to center ADC event
@@ -103,7 +103,7 @@ def constructor(
     noise_scan
         If true, a noise scan is acquired after each echo train, with the same duration as the echo train
     system
-        Sequence system to be used for sequence construction       
+        Sequence system to be used for sequence construction
 
     Returns
     -------


### PR DESCRIPTION
This PR unifies the usage of default_system for all sequences. Also fixes docstrings by removing "optional" and "default" comments as this is not recommended. Also adapts the default system to standard settings used for sequence programming.  