### PR TITLE
Transmit LUT for RFPA Gain Correction

### DIFF
--- a/examples/example_device_config.yaml
+++ b/examples/example_device_config.yaml
@@ -27,6 +27,8 @@ TxConfiguration:
   gpa_gain: [7.10, 7.10, 7.10]
   # Scales RF in Hz (pulseq) to mV
   rf_to_mvolt: 5.e-3
+  # rf_gain_lut_path: "/path/to/lut.npy"
+
 
 # >> RX DEVICE: M2p.5933-x4 -> /dev/spcm0 (Digitizer)
 # Total number of receive channels: 8

--- a/src/console/interfaces/device_configuration.py
+++ b/src/console/interfaces/device_configuration.py
@@ -1,4 +1,5 @@
 """Implementation of the device configuration models."""
+from pathlib import Path
 from typing import Annotated, Literal
 
 from pydantic import BaseModel, Field, model_validator
@@ -27,6 +28,7 @@ class TxConfiguration(BaseModel):
     gradient_efficiency: tuple[float, float, float] = Field(...)
     gpa_gain: tuple[float, float, float] = Field(...)
     rf_to_mvolt: float = Field(..., strict=True)
+    rf_gain_lut_path: Path | None = Field(default=None)
 
 
 class RxConfiguration(BaseModel):

--- a/src/console/pulseq_interpreter/sequence_provider.py
+++ b/src/console/pulseq_interpreter/sequence_provider.py
@@ -131,6 +131,7 @@ class SequenceProvider(Sequence):
         self._rf_gain_lut: np.ndarray | None = None
         if rf_gain_lut_path is not None and rf_gain_lut_path.exists():
             if (_lut := np.load(rf_gain_lut_path)).size == INT16_MAX - INT16_MIN + 1:
+                self.log.info("Loaded LUT for RF gain correction.")
                 self._rf_gain_lut = _lut
 
 
@@ -515,7 +516,7 @@ class SequenceProvider(Sequence):
             self.log.exception(err, exc_info=True)
 
         rf_waveform_i16 = rf_waveform.real.astype(np.int16)
-        if self._rf_gain_lut:
+        if self._rf_gain_lut is not None:
             rf_waveform_i16 = self._rf_gain_lut[rf_waveform_i16.view(np.uint16)]
 
         return (rf_waveform_i16, rf_unblanking)

--- a/src/console/pulseq_interpreter/sequence_provider.py
+++ b/src/console/pulseq_interpreter/sequence_provider.py
@@ -3,9 +3,9 @@ import logging
 from collections.abc import Callable
 from dataclasses import dataclass
 from math import floor
+from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
-from pathlib import Path
 
 import numpy as np
 from pypulseq.opts import Opts
@@ -643,18 +643,20 @@ class SequenceProvider(Sequence):
 
     def _load_rfpa_lut(self, rf_gain_lut_path: Path | None) -> None:
         if rf_gain_lut_path is None or not rf_gain_lut_path.exists():
-            self.log.info(f"No RFPA LUT file.")
+            self.log.info("No RFPA LUT file.")
             return
-        
+
         _lut = np.load(rf_gain_lut_path)
         _required_lut_size = INT16_MAX - INT16_MIN + 1
-        
+
         if _lut.size != _required_lut_size:
-            self.log.warning(f"Error loading RFPA gain LUT, invalid size. Loaded size: {_lut.size}, required: {_required_lut_size}")
+            self.log.warning(
+                f"Error loading RFPA LUT: Invalid size.\nLoaded: {_lut.size}, required: {_required_lut_size}"
+            )
             return
         if _lut.dtype != np.int16:
             self.log.warning(f"Invalid data type of RFPA gain LUT: {_lut.dtype}")
             return
-        
+
         self.log.info("Successfully loaded LUT for RF gain correction.")
         self._rf_gain_lut = _lut

--- a/src/console/pulseq_interpreter/sequence_provider.py
+++ b/src/console/pulseq_interpreter/sequence_provider.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from math import floor
 from types import SimpleNamespace
 from typing import Any
+from pathlib import Path
 
 import numpy as np
 from pypulseq.opts import Opts
@@ -69,6 +70,7 @@ class SequenceProvider(Sequence):
         rf_to_mvolt: float,
         spcm_dwell_time: float,
         system: Opts,
+        rf_gain_lut_path: Path | None = None,
     ):
         """Initialize sequence provider class which is used to unroll a pulseq sequence.
 
@@ -124,6 +126,13 @@ class SequenceProvider(Sequence):
         signal = np.exp(2j * np.pi * REFERENCE_FREQUENCY * time)
         self.phase_reference = np.zeros(NUM_REFERENCE_SAMPLES, dtype=np.uint16)
         self.phase_reference[signal > 0] = np.uint16(2**15)
+
+        # Load LUT for RF gain correction if path to LUT is provided
+        self._rf_gain_lut: np.ndarray | None = None
+        if rf_gain_lut_path is not None and rf_gain_lut_path.exists():
+            if (_lut := np.load(rf_gain_lut_path)).size == INT16_MAX - INT16_MIN + 1:
+                self._rf_gain_lut = _lut
+
 
     # -------- PyPulseq interface -------- #
 
@@ -348,9 +357,8 @@ class SequenceProvider(Sequence):
                 rf_start = block_pos[event_idx] * 4
                 rf_end = (block_pos[event_idx] + rf_size) * 4
 
-                # Add RF waveform
-                _seq[rf_start:rf_end:4] = rf_waveform.real.astype(np.int16)
-                # Add unblanking signal to Z gradient
+                # Add RF waveform and unblanking signal to Z gradient
+                _seq[rf_start:rf_end:4] = rf_waveform
                 _seq[rf_start + 3:rf_end + 3:4] = _seq[rf_start + 3:rf_end + 3:4] | rf_unblanking
 
             if block.label is not None:
@@ -502,11 +510,15 @@ class SequenceProvider(Sequence):
         carrier = np.exp(2j * np.pi * (larmor_frequency + block.freq_offset) * carrier_time)
 
         try:
-            waveform_rf = np.concatenate((np.zeros(num_samples_delay, dtype=complex), (envelope * carrier)))
+            rf_waveform = np.concatenate((np.zeros(num_samples_delay, dtype=complex), (envelope * carrier)))
         except IndexError as err:
             self.log.exception(err, exc_info=True)
 
-        return (waveform_rf, rf_unblanking)
+        rf_waveform_i16 = rf_waveform.real.astype(np.int16)
+        if self._rf_gain_lut:
+            rf_waveform_i16 = self._rf_gain_lut[rf_waveform_i16.view(np.uint16)]
+
+        return (rf_waveform_i16, rf_unblanking)
 
     @profile
     def _calculate_gradient(

--- a/src/console/pulseq_interpreter/sequence_provider.py
+++ b/src/console/pulseq_interpreter/sequence_provider.py
@@ -129,10 +129,7 @@ class SequenceProvider(Sequence):
 
         # Load LUT for RF gain correction if path to LUT is provided
         self._rf_gain_lut: np.ndarray | None = None
-        if rf_gain_lut_path is not None and rf_gain_lut_path.exists():
-            if (_lut := np.load(rf_gain_lut_path)).size == INT16_MAX - INT16_MIN + 1:
-                self.log.info("Loaded LUT for RF gain correction.")
-                self._rf_gain_lut = _lut
+        self._load_rfpa_lut(rf_gain_lut_path)
 
 
     # -------- PyPulseq interface -------- #
@@ -495,7 +492,7 @@ class SequenceProvider(Sequence):
             # RF scaling according to B1 calibration and "device" (translation from pulseq to output voltage)
             rf_scaling = b1_scaling * self.rf_to_mvolt * phase_offset / self.rf_out_limit
             if np.abs(np.amax(envelope_scaled := block.signal * rf_scaling)) > 1:
-                raise ValueError("RF magnitude exceeds output limit.")
+                raise ValueError(f"RF magnitude exceeds output limit by {np.amax(envelope_scaled)*100}%.")
         except ValueError as err:
             self.log.exception(err, exc_info=True)
             raise err
@@ -517,7 +514,7 @@ class SequenceProvider(Sequence):
 
         rf_waveform_i16 = rf_waveform.real.astype(np.int16)
         if self._rf_gain_lut is not None:
-            rf_waveform_i16 = self._rf_gain_lut[rf_waveform_i16.view(np.uint16)]
+            rf_waveform_i16 = self._rf_gain_lut[rf_waveform_i16+INT16_MIN]
 
         return (rf_waveform_i16, rf_unblanking)
 
@@ -643,3 +640,21 @@ class SequenceProvider(Sequence):
         check, seq_err = self.check_timing()
         if not check:
             raise ValueError(f"Sequence timing check failed: {seq_err}")
+
+    def _load_rfpa_lut(self, rf_gain_lut_path: Path | None) -> None:
+        if rf_gain_lut_path is None or not rf_gain_lut_path.exists():
+            self.log.info(f"No RFPA LUT file.")
+            return
+        
+        _lut = np.load(rf_gain_lut_path)
+        _required_lut_size = INT16_MAX - INT16_MIN + 1
+        
+        if _lut.size != _required_lut_size:
+            self.log.warning(f"Error loading RFPA gain LUT, invalid size. Loaded size: {_lut.size}, required: {_required_lut_size}")
+            return
+        if _lut.dtype != np.int16:
+            self.log.warning(f"Invalid data type of RFPA gain LUT: {_lut.dtype}")
+            return
+        
+        self.log.info("Successfully loaded LUT for RF gain correction.")
+        self._rf_gain_lut = _lut

--- a/src/console/spcm_control/acquisition_control.py
+++ b/src/console/spcm_control/acquisition_control.py
@@ -86,6 +86,7 @@ class AcquisitionControl:
             spcm_dwell_time=1 / (self.config.tx.sampling_rate * 1e6),
             rf_to_mvolt=self.config.tx.rf_to_mvolt,
             system=self.config.system.get_opts(),
+            rf_gain_lut_path=self.config.tx.rf_gain_lut_path,
         )
         # Create transmit card instance
         self.tx_card: TxCard = TxCard(

--- a/src/console/utilities/json_encoder.py
+++ b/src/console/utilities/json_encoder.py
@@ -1,6 +1,7 @@
 """Implementation of custom JSON encoder."""
 import dataclasses
 import json
+from pathlib import Path
 from typing import Any
 
 
@@ -21,4 +22,6 @@ class JSONEncoder(json.JSONEncoder):
         """
         if bool(dataclasses.is_dataclass(obj)) and not isinstance(obj, type):
             return dataclasses.asdict(obj)
+        if isinstance(obj, Path):
+            return str(obj)
         return super().default(obj)

--- a/src/console/utilities/json_encoder.py
+++ b/src/console/utilities/json_encoder.py
@@ -2,13 +2,12 @@
 import dataclasses
 import json
 from pathlib import Path
-from typing import Any
 
 
 class JSONEncoder(json.JSONEncoder):
     """JSON Encoder class."""
 
-    def default(self, obj) -> dict[str, Any]:
+    def default(self, obj) -> object:
         """Encode object default method.
 
         Parameters

--- a/src/console/utilities/plot.py
+++ b/src/console/utilities/plot.py
@@ -45,7 +45,7 @@ def plot_unrolled_sequence(
     unblanking = gz_signal.astype(np.uint16) >> 15
 
     # Get gradient waveforms
-    rf_signal = rf_signal / np.abs(np.iinfo(np.int16).min)
+    rf_signal = rf_signal / np.iinfo(np.int16).max
     gx_signal = np.array((np.uint16(gx_signal) << 1).astype(np.int16) / 2**15)
     gy_signal = np.array((np.uint16(gy_signal) << 1).astype(np.int16) / 2**15)
     gz_signal = np.array((np.uint16(gz_signal) << 1).astype(np.int16) / 2**15)

--- a/tests/sequence_tests/test_sequence_provider.py
+++ b/tests/sequence_tests/test_sequence_provider.py
@@ -212,7 +212,7 @@ def test_calculate_rf_block(seq_provider: SequenceProvider):
     # Basic checks
     assert isinstance(rf_waveform, np.ndarray)
     assert isinstance(rf_unblanking, np.ndarray)
-    assert rf_waveform.dtype == complex
+    assert rf_waveform.dtype != complex
     assert rf_unblanking.dtype == np.uint16
 
     # Number of computed RF samples must follow logic:


### PR DESCRIPTION
This PR introduces a look-up-table (LUT) for RFPA gain correction. The LUT is loaded from a numpy file and the path to that file can be configured in the device configuration yaml file. The LUT must contain exactly 65,536 int16 values. After calculating the int16 RF waveform from pulseq the LUT is applied within the `SequenceProvider` class.

The difference between the expected (Reference) and actual power (Measured) can be demonstrated by a loop-back measurement of the attenuated RFPA output (attenutation compensates gain).

<img width="416" height="300" alt="measured_and_reference_power" src="https://github.com/user-attachments/assets/576c3609-8adc-4315-afc6-cf77f514a799" />

From the deviation, a correction factor proportional to the output voltage can be calculated, which is then translated into the LUT.
Repeating the experiment with the LUT applied yields the following result.

<img width="416" height="300" alt="measured_and_reference_power" src="https://github.com/user-attachments/assets/02dcd00e-afd1-4cd7-abbc-e7293db5aaf7" />
