### PR TITLE
Acquisition progress callback

### DIFF
--- a/src/console/spcm_control/acquisition_control.py
+++ b/src/console/spcm_control/acquisition_control.py
@@ -221,7 +221,7 @@ class AcquisitionControl:
         self.sequence = self.seq_provider.unroll_sequence(parameter=parameter)
         self.log.info("Sequence duration: %s s", self.sequence.duration)
 
-    def run(self, store_unprocessed: bool = False, progress_callback: Callable[[float], None] | None = None) -> AcquisitionData:
+    def run(self, store_unprocessed: bool = False, progress_callback: Callable[[int], None] | None = None) -> AcquisitionData:
         """Run an acquisition job.
 
         Parameters
@@ -288,13 +288,17 @@ class AcquisitionControl:
 
             # Get start time of acquisition
             time_start = time.time()
+            last_progress_step = -1
 
             while (num_gates := self.rx_card.total_gates) < self.sequence.adc_count or num_gates == 0:
                 if callable(progress_callback):
-                    progress_callback(num_gates/self.sequence.adc_count)
+                    progress = int(100 * num_gates / self.sequence.adc_count)
+                    if progress > last_progress_step + 2:
+                        last_progress_step = progress
+                        progress_callback(progress)
 
-                # Delay poll by 10 ms
-                time.sleep(0.01)
+                # Delay poll by 100 ms
+                time.sleep(0.1)
 
                 if (time.time() - time_start) > timeout:
                     # Could not receive all the data before timeout

--- a/src/console/spcm_control/acquisition_control.py
+++ b/src/console/spcm_control/acquisition_control.py
@@ -6,6 +6,7 @@ import logging
 import logging.config
 import os
 import time
+from collections.abc import Callable
 from datetime import datetime
 from pathlib import Path
 from typing import cast
@@ -15,7 +16,6 @@ import numpy as np
 from pypulseq import Opts
 
 from console.interfaces.acquisition_data import AcquisitionData
-from collections.abc import Callable
 from console.interfaces.acquisition_parameter import AcquisitionParameter
 from console.interfaces.device_configuration import NexusConfiguration
 from console.interfaces.dimensions import Dimensions
@@ -221,7 +221,11 @@ class AcquisitionControl:
         self.sequence = self.seq_provider.unroll_sequence(parameter=parameter)
         self.log.info("Sequence duration: %s s", self.sequence.duration)
 
-    def run(self, store_unprocessed: bool = False, progress_callback: Callable[[int], None] | None = None) -> AcquisitionData:
+    def run(
+        self,
+        store_unprocessed: bool = False,
+        progress_callback: Callable[[int], None] | None = None,
+    ) -> AcquisitionData:
         """Run an acquisition job.
 
         Parameters

--- a/src/console/spcm_control/acquisition_control.py
+++ b/src/console/spcm_control/acquisition_control.py
@@ -15,6 +15,7 @@ import numpy as np
 from pypulseq import Opts
 
 from console.interfaces.acquisition_data import AcquisitionData
+from collections.abc import Callable
 from console.interfaces.acquisition_parameter import AcquisitionParameter
 from console.interfaces.device_configuration import NexusConfiguration
 from console.interfaces.dimensions import Dimensions
@@ -220,7 +221,7 @@ class AcquisitionControl:
         self.sequence = self.seq_provider.unroll_sequence(parameter=parameter)
         self.log.info("Sequence duration: %s s", self.sequence.duration)
 
-    def run(self, store_unprocessed: bool = False) -> AcquisitionData:
+    def run(self, store_unprocessed: bool = False, progress_callback: Callable[[float], None] | None = None) -> AcquisitionData:
         """Run an acquisition job.
 
         Parameters
@@ -289,6 +290,9 @@ class AcquisitionControl:
             time_start = time.time()
 
             while (num_gates := self.rx_card.total_gates) < self.sequence.adc_count or num_gates == 0:
+                if callable(progress_callback):
+                    progress_callback(num_gates/self.sequence.adc_count)
+
                 # Delay poll by 10 ms
                 time.sleep(0.01)
 


### PR DESCRIPTION
This PR adds a callback function to the `run` method of the `AcquisitionControl`. It allows to provide a function which reports the progress, i.e. the percentage of acquired ADC gates e.g. to a ScanHub. The progress is reported at a step size of 2% and the delay between ADC gate polls was increased to 100 ms.  